### PR TITLE
fix: handle UID 0 (root user) case in docker-entrypoint.sh

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/DEV-LOGS.md
+++ b/DEV-LOGS.md
@@ -9,9 +9,11 @@
 
 **Problem**: `sudo claude-yolo` fails with "usermod: UID '0' already exists" error.
 
-**Solution**: Detect UID=0 and GID=0 cases independently, use fallback UID/GID 1000.
+**Root Cause**: Can't reassign existing UID 0 (root) to claude user.
 
-**Security Fix**: Prevent container user getting root group when host has GID=0 but UID≠0.
+**Security Fix**: Handle UID=0 and GID=0 independently to prevent root group assignment.
+
+**Solution**: Use fallback UID/GID 1000 for proper file ownership with existing collision handling.
 
 **Status**: ✅ **COMPLETED** - PR #22
 

--- a/DEV-LOGS.md
+++ b/DEV-LOGS.md
@@ -5,6 +5,20 @@
 
 ## Issue Analysis: 2025-06-23
 
+### [bug-fixed] Claude Code Review OIDC token authentication error
+
+**Problem**: CI failing with "Invalid OIDC token" after changing permissions to write.
+
+**Solution**: Added explicit `github_token: ${{ secrets.GITHUB_TOKEN }}` to force direct token auth.
+
+**Cause**: Write permissions trigger GitHub App auth by default, but no App configured.
+
+**Status**: ✅ **COMPLETED**
+
+---
+
+## Issue Analysis: 2025-06-23
+
 ### [enhancement-completed] Claude Code Review workflow simplification
 
 **Problem**: Overcomplicated workflow with manual duplicate detection using GitHub CLI.

--- a/DEV-LOGS.md
+++ b/DEV-LOGS.md
@@ -5,6 +5,20 @@
 
 ## Issue Analysis: 2025-06-23
 
+### [bug-fixed] Root user (UID 0) handling in docker-entrypoint.sh
+
+**Problem**: `sudo claude-yolo` fails with "usermod: UID '0' already exists" error.
+
+**Solution**: Detect UID=0 and GID=0 cases independently, use fallback UID/GID 1000.
+
+**Security Fix**: Prevent container user getting root group when host has GID=0 but UID≠0.
+
+**Status**: ✅ **COMPLETED** - PR #22
+
+---
+
+## Issue Analysis: 2025-06-23
+
 ### [bug-fixed] Claude Code Review OIDC token authentication error
 
 **Problem**: CI failing with "Invalid OIDC token" after changing permissions to write.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,13 +59,11 @@ setup_nonroot_user() {
     local current_uid=$(id -u "$CLAUDE_USER")
     local current_gid=$(id -g "$CLAUDE_USER")
 
-    # Handle UID=0 case (host user is root)
     if [ "$CLAUDE_UID" = "0" ]; then
         echo "[entrypoint] WARNING: Host user is root (UID=0). Using fallback UID 1000 for security."
         CLAUDE_UID=1000
     fi
 
-    # Handle GID=0 case (host user in root group)
     if [ "$CLAUDE_GID" = "0" ]; then
         echo "[entrypoint] WARNING: Host user is in root group (GID=0). Using fallback GID 1000 for security."
         CLAUDE_GID=1000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -59,6 +59,17 @@ setup_nonroot_user() {
     local current_uid=$(id -u "$CLAUDE_USER")
     local current_gid=$(id -g "$CLAUDE_USER")
 
+    # Handle UID=0 case (host user is root)
+    if [ "$CLAUDE_UID" = "0" ]; then
+        echo "[entrypoint] WARNING: Host user is root (UID=0). Using fallback UID 1000 for security."
+        echo "[entrypoint] Container runs as non-root claude user but files will be owned by root on host."
+        CLAUDE_UID=1000
+        # Also use fallback GID if it was 0
+        if [ "$CLAUDE_GID" = "0" ]; then
+            CLAUDE_GID=1000
+        fi
+    fi
+
     if [ "$CLAUDE_GID" != "$current_gid" ]; then
         [ "$VERBOSE" = "true" ] && echo "[entrypoint] updating $CLAUDE_USER GID: $current_gid -> $CLAUDE_GID"
         if getent group "$CLAUDE_GID" >/dev/null 2>&1; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -60,23 +60,13 @@ setup_nonroot_user() {
     local current_gid=$(id -g "$CLAUDE_USER")
 
     if [ "$CLAUDE_UID" = "0" ]; then
-        # Find first available UID starting from 1000
-        fallback_uid=1000
-        while getent passwd "$fallback_uid" >/dev/null 2>&1; do
-            fallback_uid=$((fallback_uid + 1))
-        done
-        echo "[entrypoint] WARNING: Host user is root (UID=0). Using fallback UID $fallback_uid for security."
-        CLAUDE_UID=$fallback_uid
+        echo "[entrypoint] WARNING: Host user is root (UID=0). Using fallback UID 1000 for security."
+        CLAUDE_UID=1000
     fi
 
     if [ "$CLAUDE_GID" = "0" ]; then
-        # Find first available GID starting from 1000
-        fallback_gid=1000
-        while getent group "$fallback_gid" >/dev/null 2>&1; do
-            fallback_gid=$((fallback_gid + 1))
-        done
-        echo "[entrypoint] WARNING: Host user is in root group (GID=0). Using fallback GID $fallback_gid for security."
-        CLAUDE_GID=$fallback_gid
+        echo "[entrypoint] WARNING: Host user is in root group (GID=0). Using fallback GID 1000 for security."
+        CLAUDE_GID=1000
     fi
 
     if [ "$CLAUDE_GID" != "$current_gid" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -62,12 +62,13 @@ setup_nonroot_user() {
     # Handle UID=0 case (host user is root)
     if [ "$CLAUDE_UID" = "0" ]; then
         echo "[entrypoint] WARNING: Host user is root (UID=0). Using fallback UID 1000 for security."
-        echo "[entrypoint] Container runs as non-root claude user but files will be owned by root on host."
         CLAUDE_UID=1000
-        # Also use fallback GID if it was 0
-        if [ "$CLAUDE_GID" = "0" ]; then
-            CLAUDE_GID=1000
-        fi
+    fi
+
+    # Handle GID=0 case (host user in root group)
+    if [ "$CLAUDE_GID" = "0" ]; then
+        echo "[entrypoint] WARNING: Host user is in root group (GID=0). Using fallback GID 1000 for security."
+        CLAUDE_GID=1000
     fi
 
     if [ "$CLAUDE_GID" != "$current_gid" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -60,13 +60,23 @@ setup_nonroot_user() {
     local current_gid=$(id -g "$CLAUDE_USER")
 
     if [ "$CLAUDE_UID" = "0" ]; then
-        echo "[entrypoint] WARNING: Host user is root (UID=0). Using fallback UID 1000 for security."
-        CLAUDE_UID=1000
+        # Find first available UID starting from 1000
+        fallback_uid=1000
+        while getent passwd "$fallback_uid" >/dev/null 2>&1; do
+            fallback_uid=$((fallback_uid + 1))
+        done
+        echo "[entrypoint] WARNING: Host user is root (UID=0). Using fallback UID $fallback_uid for security."
+        CLAUDE_UID=$fallback_uid
     fi
 
     if [ "$CLAUDE_GID" = "0" ]; then
-        echo "[entrypoint] WARNING: Host user is in root group (GID=0). Using fallback GID 1000 for security."
-        CLAUDE_GID=1000
+        # Find first available GID starting from 1000
+        fallback_gid=1000
+        while getent group "$fallback_gid" >/dev/null 2>&1; do
+            fallback_gid=$((fallback_gid + 1))
+        done
+        echo "[entrypoint] WARNING: Host user is in root group (GID=0). Using fallback GID $fallback_gid for security."
+        CLAUDE_GID=$fallback_gid
     fi
 
     if [ "$CLAUDE_GID" != "$current_gid" ]; then


### PR DESCRIPTION
Fixes ##21 - docker-entrypoint.sh fails when host user is root (UID 0)

## Changes
- Fixed security vulnerability: handle UID=0 and GID=0 independently  
- Prevent container user getting root group (GID=0) when host UID≠0 but GID=0
- Use fallback UID/GID 1000 for both root user and root group cases
- Remove inaccurate file ownership warning message
- Fix Claude Code Review CI authentication (OIDC token → direct GitHub token)

## Security Fix
Addresses Cursor BugBot report: nested GID=0 check allowed security bypass where container claude user could be assigned root group privileges.

## Testing  
- [x] Logic validated in code review
- [x] CI authentication fixed
- [ ] Requires testing with actual root user (`sudo claude-yolo`)

Generated with [Claude Code](https://claude.ai/code)