### PR TITLE
refactor: migrate repository from lroolle to thevibeworks org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: thevibeworks/ccyolo
 
 jobs:
   build-and-push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to claude-code-yolo will be documented in this file.
+All notable changes to Claude Code YOLO will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -120,7 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2025-06-21
 
 ### Added
-- Initial release of claude-code-yolo Docker wrapper
+- Initial release of Claude Code YOLO Docker wrapper
 - Dual-mode architecture: Local mode (default) and YOLO mode (Docker)
 - Support for 4 authentication methods:
   - Claude App OAuth (`--claude`, `-c`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2025-07-10
+
+### Changed
+- Migrate repository from lroolle to thevibeworks org
+
 ## [0.4.1] - 2025-07-08
 
 ### Changed

--- a/DEV-LOGS.md
+++ b/DEV-LOGS.md
@@ -1,8 +1,32 @@
-# Development Logs
-- Prepend new entries with `## Dev Log: YYYY-MM-DD`.
-- Reference issue numbers in the format `#<issue-number>` for easy linking.
+# Development Logs & WIPs
+- Prepend new entries with:
+  ```markdown
+  # [YYYY-MM-DD] Dev Log: <Subject>
+  - Why: <one-line reason>
+  - What: <brief list of changes>
+  - Result: <outcome/impact>
+  ```
+- Prepend new WIP within the `# WIP` section.
+  - use `- [ ]` for tasks, `- [x]` for completed items.
 - We write or explain to the damn point. Be clear, be super concise - no fluff, no hand-holding, no repeating.
-- Minimal markdown markers, no unnecessary formatting, minimal unicode emojis.
+- Be specific about what was done, why it was done, and any important context.
+- Minimal markdown markers, no unnecessary formatting, minimal emojis.
+- Reference issue numbers in the format `#<issue-number>` for easy linking.
+
+# [2025-07-10] Dev Log: Complete namespace migration to thevibeworks
+- Why: Migrate from lroolle org to thevibeworks, shorten Docker image name for cleaner registry
+- What: Updated all references, Docker images, URLs across entire codebase, kept command name for backward compatibility
+- Result: Clean migration with repo at thevibeworks/claude-code-yolo, Docker image at thevibeworks/ccyolo, command stays claude-yolo
+
+**Changes Made**:
+- Repo: `lroolle/claude-code-yolo` → `thevibeworks/claude-code-yolo`
+- Docker: `ghcr.io/lroolle/claude-code-yolo` → `ghcr.io/thevibeworks/ccyolo`
+- Command: Kept `claude-yolo` (backward compatibility)
+- Project: Kept "Claude Code YOLO" title
+
+**Files Updated**: Makefile, README.md, CLAUDE.md, claude.sh, claude-yolo, install.sh, Dockerfile, CHANGELOG.md, DEV-LOGS.md, scripts/, claude-yolo-pro/
+
+Addresses issue #48.
 
 ## Dev Log: 2025-07-09
 
@@ -10,7 +34,7 @@
 
 **Problem**: Messy auth flags, poor environment handling, inconsistent Docker mounts.
 
-**Solution**: 
+**Solution**:
 - Unified auth with `--auth-with` pattern (claude|api-key|bedrock|vertex)
 - Proper environment var handling with `-e` flag
 - Controlled auth directory mounting with explicit permissions
@@ -89,7 +113,7 @@ claude-yolo -v ~/.ssh:/root/.ssh:ro -v ~/Desktop/claude:/home/claude/.claude/ -v
 version: '3.8'
 services:
   claude:
-    image: ghcr.io/lroolle/claude-code-yolo:latest
+    image: ghcr.io/thevibeworks/ccyolo:latest
     volumes:
       - ~/.ssh:/root/.ssh:ro
       - ${PWD}:${PWD}
@@ -318,7 +342,7 @@ services:
 - **Startup**: Two-line summary with key info:
   ```
   Claude Code YOLO v0.2.0 | Auth: OAuth | Working: /path/to/project
-  Container: claude-code-yolo-myproject-12345
+  Container: ccyolo-myproject-12345
   ```
 - **Flags**: Added --quiet and --verbose for user control over output verbosity
 
@@ -630,7 +654,7 @@ Cons: Added complexity, manifest management
 
 #### Option 3: Layered Image Approach
 ```dockerfile
-FROM lroolle/claude-code-yolo:base
+FROM thevibeworks/ccyolo:base
 RUN install-tool gh terraform kubectl
 ```
 Pros: Docker-native, cacheable layers

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 
 FROM ubuntu:24.04 AS base
 
-LABEL maintainer="github.com/lroolle"
-LABEL org.opencontainers.image.title="claude-code-yolo"
+LABEL maintainer="github.com/thevibeworks"
+LABEL org.opencontainers.image.title="ccyolo"
 LABEL org.opencontainers.image.description="Safe Claude Code CLI with full dev environment"
 LABEL org.opencontainers.image.licenses="MIT"
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
-IMAGE_NAME := ghcr.io/lroolle/claude-code-yolo
+IMAGE_NAME := ghcr.io/thevibeworks/ccyolo
 TAG := latest
-CONTAINER_NAME := claude-code-yolo-$(shell basename $(PWD))-$(shell date +%s)
+CONTAINER_NAME := ccyolo-$(shell basename $(PWD))-$(shell date +%s)
 CLAUDE_CODE_VERSION := 1.0.44
 
 export DOCKER_BUILDKIT := 1
@@ -10,13 +10,13 @@ export DOCKER_BUILDKIT := 1
 
 .PHONY: build
 build:
-	@echo "🔨 Building Claude Code YOLO Docker image..."
+	@echo "🔨 Building CCYOLO Docker image..."
 	docker build --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) -t $(IMAGE_NAME):$(TAG) .
 	@echo "✅ Build completed: $(IMAGE_NAME):$(TAG)"
 
 .PHONY: rebuild
 rebuild:
-	@echo "🔨 Rebuilding Claude Code YOLO Docker image (no cache)..."
+	@echo "🔨 Rebuilding CCYOLO Docker image (no cache)..."
 	docker build --no-cache --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) -t $(IMAGE_NAME):$(TAG) .
 	@echo "✅ Rebuild completed: $(IMAGE_NAME):$(TAG)"
 
@@ -156,8 +156,8 @@ release-major:
 
 .PHONY: help
 help:
-	@echo "Claude Code YOLO - Docker Build Shortcuts"
-	@echo "=========================================="
+	@echo "CCYOLO - Docker Build Shortcuts"
+	@echo "==============================="
 	@echo ""
 	@echo "Usage: make [target]"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ export DOCKER_BUILDKIT := 1
 
 .PHONY: build
 build:
-	@echo "🔨 Building CCYOLO Docker image..."
+	@echo "🔨 Building Claude Code YOLO Docker image..."
 	docker build --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) -t $(IMAGE_NAME):$(TAG) .
 	@echo "✅ Build completed: $(IMAGE_NAME):$(TAG)"
 
 .PHONY: rebuild
 rebuild:
-	@echo "🔨 Rebuilding CCYOLO Docker image (no cache)..."
+	@echo "🔨 Rebuilding Claude Code YOLO Docker image (no cache)..."
 	docker build --no-cache --build-arg CLAUDE_CODE_VERSION=$(CLAUDE_CODE_VERSION) -t $(IMAGE_NAME):$(TAG) .
 	@echo "✅ Rebuild completed: $(IMAGE_NAME):$(TAG)"
 
@@ -156,7 +156,7 @@ release-major:
 
 .PHONY: help
 help:
-	@echo "CCYOLO - Docker Build Shortcuts"
+	@echo "Claude Code YOLO - Docker Build Shortcuts"
 	@echo "==============================="
 	@echo ""
 	@echo "Usage: make [target]"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Docker-based Claude Code CLI with full development capabilities and host isolati
 
 ```bash
 # One-line install
-curl -fsSL https://raw.githubusercontent.com/lroolle/claude-code-yolo/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/thevibeworks/claude-code-yolo/main/install.sh | bash
 
 ```
 
@@ -141,20 +141,20 @@ Claude Code YOLO is available from multiple container registries:
 
 ```bash
 # GitHub Container Registry (recommended, primary)
-docker pull ghcr.io/lroolle/claude-code-yolo:latest
+docker pull ghcr.io/thevibeworks/ccyolo:latest
 
 # Docker Hub (fallback)
-docker pull lroolle/claude-code-yolo:latest
+docker pull thevibeworks/ccyolo:latest
 
 # Use specific registry
-CCYOLO_DOCKER_IMAGE=lroolle/claude-code-yolo claude-yolo
+CCYOLO_DOCKER_IMAGE=thevibeworks/ccyolo claude-yolo
 ```
 
 ## Manual Setup
 
 ```bash
 # Clone repository
-git clone https://github.com/lroolle/claude-code-yolo.git
+git clone https://github.com/thevibeworks/claude-code-yolo.git
 cd claude-code-yolo
 
 # Build from source (optional)

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,7 @@
 - [X] Resolve auth mounting inconsistency (`/root/` vs `/home/claude/`)
 - [x] Fix credential sync - Use permission + symlink approach instead of copying
 - [x] Fix --dangerously-skip-permissions consistency in non-root mode
-- [x] Add Docker socket security control via CLAUDE_YOLO_DOCKER_SOCKET env var
-- [x] Gate Docker socket mount behind `CLAUDE_YOLO_DOCKER_SOCKET=true` env var (default: off)
+- [x] Add Docker socket security control via CCYOLO_DOCKER_SOCKET env var
+- [x] Gate Docker socket mount behind `CCYOLO_DOCKER_SOCKET=true` env var (default: off)
 - [x] Make risky mounts opt-in, not default
 - [x] `check_dangerous_directory`

--- a/claude-yolo
+++ b/claude-yolo
@@ -7,7 +7,7 @@ CLAUDE_SH="$SCRIPT_DIR/claude.sh"
 
 if [ ! -f "$CLAUDE_SH" ]; then
     echo "Error: claude.sh not found at $CLAUDE_SH" >&2
-    echo "Make sure you're running this from the claude-code-yolo directory" >&2
+    echo "Make sure you're running this from the ccyolo directory" >&2
     exit 1
 fi
 
@@ -19,7 +19,7 @@ fi
 
 CURRENT_DIR="$(pwd)"
 CURRENT_DIR_BASENAME="$(basename "$CURRENT_DIR")"
-CONTAINER_PATTERN="claude-code-yolo-${CURRENT_DIR_BASENAME}-"
+CONTAINER_PATTERN="ccyolo-${CURRENT_DIR_BASENAME}-"
 
 find_project_containers() {
     docker ps --filter "name=$CONTAINER_PATTERN" --format "{{.Names}}" 2>/dev/null
@@ -129,7 +129,7 @@ parse_args() {
             echo "                Can be used multiple times"
             echo ""
             echo "Examples:"
-            echo "  claude-yolo                                         # Run Claude in YOLO mode"
+            echo "  claude-yolo                                          # Run Claude in YOLO mode"
             echo "  CCYOLO_DOCKER_IMAGE=custom-image claude-yolo        # Use custom image"
             echo "  claude-yolo --inspect                               # Quick access to running container"
             echo "  claude-yolo --ps                                    # See project containers"

--- a/claude-yolo
+++ b/claude-yolo
@@ -7,7 +7,7 @@ CLAUDE_SH="$SCRIPT_DIR/claude.sh"
 
 if [ ! -f "$CLAUDE_SH" ]; then
     echo "Error: claude.sh not found at $CLAUDE_SH" >&2
-    echo "Make sure you're running this from the ccyolo directory" >&2
+    echo "Make sure you're running this from the claude-code-yolo directory" >&2
     exit 1
 fi
 

--- a/claude.sh
+++ b/claude.sh
@@ -5,7 +5,7 @@ set -e
 # Runs Claude Code CLI locally or in a Docker container for safe execution
 
 VERSION="0.4.1"
-DOCKER_IMAGE="${CCYOLO_DOCKER_IMAGE:-ghcr.io/lroolle/claude-code-yolo}"
+DOCKER_IMAGE="${CCYOLO_DOCKER_IMAGE:-ghcr.io/thevibeworks/ccyolo}"
 DOCKER_TAG="${CCYOLO_DOCKER_TAG:-latest}"
 
 DEFAULT_ANTHROPIC_MODEL="sonnet-4"
@@ -474,7 +474,7 @@ check_image
 CURRENT_DIR="$(pwd)"
 CURRENT_DIR_BASENAME="$(basename "$CURRENT_DIR")"
 
-CONTAINER_NAME="claude-code-yolo-${CURRENT_DIR_BASENAME}-$$"
+CONTAINER_NAME="ccyolo-${CURRENT_DIR_BASENAME}-$$"
 
 DOCKER_ARGS=(
     "run"
@@ -751,7 +751,7 @@ case "$AUTH_MODE" in
 *) AUTH_STATUS="$(green 'OAuth')" ;;
 esac
 
-HEADER_LINE="$(green ">>> CLAUDE-YOLO v$VERSION") | $AUTH_STATUS"
+HEADER_LINE="$(green ">>> Claude Code YOLO v$VERSION") | $AUTH_STATUS"
 [ "$USE_TRACE" = true ] && HEADER_LINE+=" | Trace:$(yellow 'ON')"
 
 echo ""

--- a/claude.sh
+++ b/claude.sh
@@ -4,7 +4,7 @@ set -e
 # Claude Starter Script with Docker Support
 # Runs Claude Code CLI locally or in a Docker container for safe execution
 
-VERSION="0.4.1"
+VERSION="0.4.2"
 DOCKER_IMAGE="${CCYOLO_DOCKER_IMAGE:-ghcr.io/thevibeworks/ccyolo}"
 DOCKER_TAG="${CCYOLO_DOCKER_TAG:-latest}"
 

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@ set -e
 
 SCRIPT_NAME="claude.sh"
 YOLO_WRAPPER="claude-yolo"
-DOCKER_IMAGE="ghcr.io/lroolle/claude-code-yolo:latest"
-GITHUB_RAW="https://raw.githubusercontent.com/lroolle/claude-code-yolo/main"
+DOCKER_IMAGE="ghcr.io/thevibeworks/ccyolo:latest"
+GITHUB_RAW="https://raw.githubusercontent.com/thevibeworks/claude-code-yolo/main"
 
 echo "Claude Code YOLO Installer"
 echo "=========================="
@@ -48,11 +48,11 @@ echo ""
 echo "Pulling Docker image..."
 if ! docker pull "$DOCKER_IMAGE"; then
     echo "Failed to pull from GitHub Container Registry, trying Docker Hub..."
-    DOCKER_IMAGE_FALLBACK="lroolle/claude-code-yolo:latest"
+    DOCKER_IMAGE_FALLBACK="thevibeworks/ccyolo:latest"
     docker pull "$DOCKER_IMAGE_FALLBACK"
     echo ""
     echo -e "\033[93mNOTE: Using Docker Hub fallback image\033[0m"
-    echo "To use Docker Hub by default, set: export DOCKER_IMAGE=lroolle/claude-code-yolo"
+    echo "To use Docker Hub by default, set: export CCYOLO_DOCKER_IMAGE=thevibeworks/ccyolo"
     echo "Add this to your shell profile (.bashrc, .zshrc) to make it permanent"
 fi
 
@@ -79,7 +79,7 @@ echo ""
 echo "3. Start with Claude YOLO:"
 echo "   claude-yolo                              # Run Claude with full permissions"
 echo ""
-echo "4. Claude-yolo handles all features:"
+echo "4. Claude YOLO handles all features:"
 echo "   claude-yolo --auth-with bedrock          # Use AWS Bedrock"
 echo "   claude-yolo --auth-with api-key          # Use API key(may have to rerun \`/login\`)"
 echo "   claude-yolo --trace                      # Enable request tracing"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,7 +39,7 @@ main() {
     check_prerequisites
     
     # Let Claude Code handle the intelligent workflow
-    local claude_cmd="${CLAUDE_YOLO_RELEASE_CMD:-$CLAUDE_YOLO}"
+    local claude_cmd="${CCYOLO_RELEASE_CMD:-$CLAUDE_YOLO}"
     
     # Expand ~ in the command (Docker needs absolute paths)
     claude_cmd="${claude_cmd//\~/$HOME}"


### PR DESCRIPTION
## Summary
- Migrate Docker image from `ghcr.io/lroolle/claude-code-yolo` to `ghcr.io/thevibeworks/ccyolo`
- Update repository URLs from `lroolle/claude-code-yolo` to `thevibeworks/claude-code-yolo`
- Standardize environment variables from `CLAUDE_YOLO_*` to `CCYOLO_*`
- Preserve `claude-yolo` command name for backward compatibility
- Update GitHub Actions workflow and documentation

## Test plan
- [ ] Verify Docker image builds correctly with new name
- [ ] Test installation script with new URLs
- [ ] Confirm backward compatibility with existing commands
- [ ] Validate GitHub Actions workflow

Closes #48

🤖 Generated with [Claude Code](https://claude.ai/code)