### PR TITLE
fix(claude.sh): disable thinking features for non-Claude 4

### DIFF
--- a/claude.sh
+++ b/claude.sh
@@ -133,9 +133,6 @@ is_claude4_model() {
     "sonnet-4" | "opus-4" | "claude-sonnet-4-20250514" | "claude-opus-4-20250514")
         return 0
         ;;
-    "sonnet-3-7" | "claude-3-7-sonnet-20250219")
-        return 0
-        ;;
     *)
         return 1
         ;;
@@ -430,10 +427,6 @@ run_claude_local() {
     echo ""
     echo "$(blue '────────────────────────────────────')"
     echo ""
-
-    if [ -n "$CONFIG_DIR" ]; then
-        export CLAUDE_CONFIG_DIR="$CONFIG_DIR/.claude"
-    fi
 
     if [ "$USE_TRACE" = true ]; then
         if command -v "$CLAUDE_TRACE_PATH" >/dev/null 2>&1; then


### PR DESCRIPTION
Disable thinking features for non-Claude 4 models to prevent compatibility issues.

## Changes
- Add is_claude4_model function to identify Claude 4 models  
- Add disable_thinking_features_local and disable_thinking_features_docker functions
- Disable thinking features for non-Claude 4 models in both local and Docker modes
- Apply to all authentication modes (claude, api-key, bedrock, vertex)

## Environment Variables Implemented
- DISABLE_INTERLEAVED_THINKING=1 - Disables thinking display
- MAX_THINKING_TOKENS=0 - Sets thinking budget to zero  
- DISABLE_PROMPT_CACHING=1 - Disables prompt caching for compatibility

## Fixes Applied
- Fixed Claude 3.7 classification bug (was incorrectly marked as Claude 4)
- Removed unrelated CLAUDE_CONFIG_DIR code
- Verified all environment variables are valid Claude Code CLI settings

Addresses #24 (thinking-related environment variables)