### PR TITLE
chore:  bump claude code v1.0.95, release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2025-08-28
+
+### Changed
+- Updated Claude Code base version to 1.0.95 with new features:
+  - /todos command to list current todo items
+  - /memory command now allows direct editing of imported memory files  
+  - MCP output warnings when responses exceed token limits (10k warning, 25k max)
+  - Enhanced slash command improvements
+
 ## [0.5.0] - 2025-08-27
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ RUN mkdir -p "$CLAUDE_HOME/.npm-global" && \
 
 # Set npm configuration for claude user and install Claude CLI
 USER $CLAUDE_USER
-ARG CLAUDE_CODE_VERSION=1.0.93
+ARG CLAUDE_CODE_VERSION=1.0.95
 RUN npm config set prefix "$CLAUDE_HOME/.npm-global" && \
     npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} @mariozechner/claude-trace && \
     npm cache clean --force

--- a/claude.sh
+++ b/claude.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION="0.5.0"
+VERSION="0.5.1"
 DOCKER_IMAGE="${CCYOLO_DOCKER_IMAGE:-ghcr.io/thevibeworks/ccyolo}"
 DOCKER_TAG="${CCYOLO_DOCKER_TAG:-latest}"
 


### PR DESCRIPTION
- Update Claude Code to v1.0.95
- Add /todos command support
- MCP output token warnings