### PR TITLE
Fix installer smoke registry dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,26 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Resolve tool versions
+        id: versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash ./scripts/resolve-tool-versions.sh
+
       - name: Build local smoke image
-        run: docker build -t deva-smoke:ci .
+        run: |
+          docker build -t deva-smoke:ci \
+            --build-arg CLAUDE_CODE_VERSION="${{ steps.versions.outputs.claude_code_version }}" \
+            --build-arg CODEX_VERSION="${{ steps.versions.outputs.codex_version }}" \
+            --build-arg GEMINI_CLI_VERSION="${{ steps.versions.outputs.gemini_cli_version }}" \
+            --build-arg ATLAS_CLI_VERSION="${{ steps.versions.outputs.atlas_cli_version }}" \
+            --build-arg COPILOT_API_VERSION="${{ steps.versions.outputs.copilot_api_version }}" \
+            .
 
       - name: Install and launch each agent without a TTY
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,19 +47,12 @@ jobs:
   smoke:
     name: Installer Smoke Test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build local smoke image
+        run: docker build -t deva-smoke:ci .
 
       - name: Install and launch each agent without a TTY
         shell: bash
@@ -68,6 +61,8 @@ jobs:
           export HOME="$(mktemp -d)"
           export PATH="$HOME/.local/bin:$PATH"
           export DEVA_INSTALL_BASE_URL="file://$PWD"
+          export DEVA_DOCKER_IMAGE="deva-smoke:ci"
+          export DEVA_DOCKER_IMAGE_FALLBACK=""
           export DEVA_NO_DOCKER=1
 
           bash ./install.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config-home fan-out skips loose credential files, backup files, VCS junk, and `.DS_Store`
 - Auth-specific persistent containers now include the agent in the name suffix, avoiding cross-agent reuse with the wrong env or mounts
 - `install.sh` now installs the full current agent set, including Gemini and `shared_auth.sh`
+- `install.sh` now reuses a prebuilt local image instead of blindly pulling, so CI smoke no longer depends on registry auth
 - release and nightly container workflows now resolve tool versions through the same script, and release no longer invents a local commit inside Actions
 
 ### Changed

--- a/install.sh
+++ b/install.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 DEVA_LAUNCHER="deva.sh"
 LEGACY_WRAPPER="claude.sh"
 YOLO_WRAPPER="claude-yolo"
-DOCKER_IMAGE="ghcr.io/thevibeworks/deva:latest"
-DOCKER_IMAGE_FALLBACK="thevibeworks/deva:latest"
+DOCKER_IMAGE="${DEVA_DOCKER_IMAGE:-ghcr.io/thevibeworks/deva:latest}"
+DOCKER_IMAGE_FALLBACK="${DEVA_DOCKER_IMAGE_FALLBACK:-thevibeworks/deva:latest}"
 INSTALL_BASE_URL="${DEVA_INSTALL_BASE_URL:-https://raw.githubusercontent.com/thevibeworks/deva/main}"
 
 agent_files=(
@@ -55,14 +55,21 @@ for file in "${agent_files[@]}"; do
 done
 
 echo ""
-echo "Pulling Docker image..."
-if ! docker pull "$DOCKER_IMAGE"; then
-    echo "GHCR pull failed. Trying Docker Hub..."
-    docker pull "$DOCKER_IMAGE_FALLBACK"
-    echo ""
-    echo "warning: using Docker Hub fallback image"
-    echo "set this if you want Docker Hub by default:"
-    echo "  export DEVA_DOCKER_IMAGE=thevibeworks/deva"
+if docker image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
+    echo "Using local Docker image: $DOCKER_IMAGE"
+else
+    echo "Pulling Docker image..."
+    if ! docker pull "$DOCKER_IMAGE"; then
+        if [ -n "$DOCKER_IMAGE_FALLBACK" ] && [ "$DOCKER_IMAGE_FALLBACK" != "$DOCKER_IMAGE" ]; then
+            echo "Primary pull failed. Trying fallback image..."
+            docker pull "$DOCKER_IMAGE_FALLBACK"
+            echo ""
+            echo "warning: using fallback image $DOCKER_IMAGE_FALLBACK"
+        else
+            echo "error: failed to pull Docker image $DOCKER_IMAGE" >&2
+            exit 1
+        fi
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- let install.sh reuse a local image instead of always pulling
- make installer smoke build its own local image in CI
- keep the 0.9.2 changelog aligned with the release blocker fix

## Verification
- shellcheck ./install.sh ./deva.sh ./scripts/resolve-tool-versions.sh
- ./scripts/version-check.sh
- DEVA_INSTALL_BASE_URL=file://$PWD DEVA_DOCKER_IMAGE=deva-smoke:test bash ./install.sh

## Context
- ghcr.io/thevibeworks/deva is currently private, so the old smoke job and public installer path were both depending on registry auth