### PR TITLE
feat(skills): add deva-clean workspace cleanup skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `skills/deva-clean`: Claude Code skill for mount-safe workspace disk
+  cleanup. Maps bind mounts from `.deva` + /proc/mounts, git-triages
+  local worktrees for unpushed/uncommitted work, and reports a tiered
+  dry-run plan before any deletion (#401)
+
 ## [0.13.0] - 2026-07-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `skills/deva-clean`: Claude Code skill for mount-safe workspace disk
-  cleanup. Maps bind mounts from `.deva` + /proc/mounts, git-triages
-  local worktrees for unpushed/uncommitted work, and reports a tiered
-  dry-run plan before any deletion (#401)
+  cleanup. `scripts/triage.sh` (read-only, deterministic) maps bind
+  mounts from /proc/mounts, git-triages local worktrees for unpushed or
+  uncommitted work via live ls-remote + merge ancestry, and emits a
+  tiered dry-run plan; SKILL.md layers the judgment calls and gates
+  execution behind explicit approval (#401)
 
 ## [0.13.0] - 2026-07-07
 

--- a/skills/deva-clean/SKILL.md
+++ b/skills/deva-clean/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: deva-clean
+description: Disk cleanup for deva container workspaces - reclaim space without touching bind mounts or unpushed work. Use when the user wants disk space reclaimed in a deva workspace, asks to remove stale worktrees, or a disk-full symptom traces into the workspace. Deleting a single known build dir needs no skill - just delete it.
+---
+
+# deva-clean: mount-safe workspace disk cleanup
+
+A deva workspace mixes two kinds of directories that look identical in
+ls: bind mounts declared in `.deva` (live host repos) and local dirs
+created during work (git worktrees, node_modules, package stores).
+rm -rf on the wrong one destroys a live repo on the host. And because
+the workspace root is itself a host mount, local dirs still consume
+host disk - usually the disk that is actually full.
+
+The run is two passes. Pass one triages everything into a dry-run plan
+and stops for approval. Pass two executes only the approved tiers.
+
+## Pass one: triage
+
+### 1. Map the mounts
+
+Read `.deva` for declared VOLUME=host:container[:mode] lines, then take
+ground truth from the kernel - config drifts, /proc/mounts does not:
+
+    grep "$(pwd)" /proc/mounts | awk '{print $2}' | sort
+
+The workspace root is usually itself a mount, so everything under it
+that is not a separate mount is a local dir living on host disk.
+
+Done when every dir under the workspace is classified mount or local.
+Mounts are off limits for the rest of the run.
+
+### 2. Locate the pressure
+
+    df -h / "$(pwd)"
+
+Overlay numbers can lie: on shared-VM runtimes (OrbStack and friends)
+overlay df reports the whole VM disk. Container-local truth:
+
+    sudo du -xh -d1 / | sort -rh | head
+
+Done when you know which disk is full. Host mount full: the workspace
+is the target. Overlay genuinely full: container caches (~/.cache,
+package stores) are the target instead.
+
+### 3. Size the candidates
+
+Candidates = the local dirs from step 1, plus stray files (shell-typo
+artifacts like "&1"). Typical: trees from `git worktree add`, one-off
+clones, node_modules, .pnpm-store.
+
+    du -sh <candidates> | sort -rh
+
+Done when every candidate has a size.
+
+### 4. Git-triage each candidate
+
+Four verdicts per candidate:
+
+- Type: `.git` file -> linked worktree; `.git` dir -> standalone repo;
+  neither -> plain dir.
+- Dirty: `git status --porcelain`. Untracked generated files (lockfiles,
+  test output) are lower risk than modified source.
+- Pushed: `git branch -r --contains HEAD` - empty output means the
+  commits exist nowhere but this machine. This is the only pushed test:
+  upstream config and ahead/behind counts are a trap (a branch created
+  off origin/develop tracks origin/develop and shows "ahead 1" while
+  never pushed itself).
+- Freshness: remote refs are only as new as the last fetch. Check
+  `stat .git/FETCH_HEAD` on the parent repo; flag stale refs in the
+  plan.
+
+Inside keepers, node_modules / dist / coverage are separately prunable:
+offer cache-prune as the low-risk alternative to removal. Also run
+`git worktree list` on each parent repo - "prunable" entries are stale
+metadata from already-deleted trees.
+
+Done when every candidate carries all four verdicts. The smallest dir
+gets the same triage as the largest: a 4M worktree can hold the only
+copy of uncommitted work.
+
+### 5. Assemble the dry-run plan
+
+- Tier 1 (safe): clean + pushed. Sizes and exact commands.
+- Tier 2 (confirm): pushed branch, dirty only with generated artifacts.
+  Offer full removal and cache-prune-only variants.
+- Keep: unpushed commits or uncommitted diffs. Say exactly what would
+  be lost and suggest pushing the branches.
+- Totals: reclaim per tier.
+
+The plan is pass one's deliverable. Present it and stop - pass two
+starts only from explicit approval, tier by tier.
+
+## Pass two: execute approved tiers
+
+- Linked worktrees: `git -C <parent> worktree remove <path>` is the
+  only removal path. Its refusal on a dirty tree is the safety net, so
+  no --force - and no rm -rf, which bypasses the net and leaves stale
+  metadata behind.
+- Stale metadata: `git -C <parent> worktree prune`.
+- Standalone repos (pushed, clean) and plain dirs: rm -rf.
+
+Safe by construction: `git worktree remove` deletes the checkout only;
+branch refs live in the parent repo's .git and survive. Committed work
+is never lost - only uncommitted files can be. The metadata edit inside
+the parent's .git is normal bookkeeping, not touching the mount.
+
+Done when df shows the reclaim and `git worktree list` on each parent
+has no leftovers.

--- a/skills/deva-clean/SKILL.md
+++ b/skills/deva-clean/SKILL.md
@@ -12,84 +12,48 @@ rm -rf on the wrong one destroys a live repo on the host. And because
 the workspace root is itself a host mount, local dirs still consume
 host disk - usually the disk that is actually full.
 
-The run is two passes. Pass one triages everything into a dry-run plan
-and stops for approval. Pass two executes only the approved tiers.
+Two passes. Pass one is deterministic and scripted; pass two executes
+only what got approved.
 
 ## Pass one: triage
 
-### 1. Map the mounts
+Run the bundled script - read-only, emits the tiered plan, never
+deletes:
 
-Read `.deva` for declared VOLUME=host:container[:mode] lines, then take
-ground truth from the kernel - config drifts, /proc/mounts does not:
+    scripts/triage.sh [workspace] [--fetch]
 
-    grep "$(pwd)" /proc/mounts | awk '{print $2}' | sort
+It maps mounts from /proc/mounts (ground truth - .deva drifts), shows
+which disk is under pressure, walks the non-mount dirs, gives every
+candidate four verdicts (type, dirty, pushed, freshness), and finds
+stale worktree metadata in the mounted parent repos. Verdict semantics
+live in the script header; two encode traps worth knowing:
 
-The workspace root is usually itself a mount, so everything under it
-that is not a separate mount is a local dir living on host disk.
+- The pushed test is live ls-remote SHA comparison plus ancestry in
+  the default branch - never upstream config. A branch created off
+  origin/develop shows "ahead 1" while never pushed itself.
+- MERGED is monotonic, provable even against stale refs. Absence is
+  not: a branch absent on remote with stale refs is UNVERIFIED, not
+  safe. Rerun with --fetch for a definitive verdict.
 
-Done when every dir under the workspace is classified mount or local.
-Mounts are off limits for the rest of the run.
+Then layer the judgment the script refuses to automate:
 
-### 2. Locate the pressure
+- Pressure: container overlay genuinely full (rare - on shared-VM
+  runtimes overlay df reports the whole VM disk) means container
+  caches (~/.cache, package stores) are the target, not the workspace.
+- Stray files: the script walks dirs only; shell-typo artifacts like
+  "&1" are yours to spot.
+- Promotions: KEEP entries flagged MODIFIED TRACKED FILES move to
+  tier 2 only when you can name every dirty file as a generated
+  artifact (lockfiles, test output) and say so in the plan.
+- Demotions: tier 1/2 entries that are functionally live - symlink
+  targets, open-PR checkouts - move to keep.
+- Keepers: offer cache-prune (node_modules, dist, coverage) as the
+  low-risk alternative; for LOCAL-ONLY work, say exactly what would
+  be lost and suggest pushing it.
 
-    df -h / "$(pwd)"
-
-Overlay numbers can lie: on shared-VM runtimes (OrbStack and friends)
-overlay df reports the whole VM disk. Container-local truth:
-
-    sudo du -xh -d1 / | sort -rh | head
-
-Done when you know which disk is full. Host mount full: the workspace
-is the target. Overlay genuinely full: container caches (~/.cache,
-package stores) are the target instead.
-
-### 3. Size the candidates
-
-Candidates = the local dirs from step 1, plus stray files (shell-typo
-artifacts like "&1"). Typical: trees from `git worktree add`, one-off
-clones, node_modules, .pnpm-store.
-
-    du -sh <candidates> | sort -rh
-
-Done when every candidate has a size.
-
-### 4. Git-triage each candidate
-
-Four verdicts per candidate:
-
-- Type: `.git` file -> linked worktree; `.git` dir -> standalone repo;
-  neither -> plain dir.
-- Dirty: `git status --porcelain`. Untracked generated files (lockfiles,
-  test output) are lower risk than modified source.
-- Pushed: `git branch -r --contains HEAD` - empty output means the
-  commits exist nowhere but this machine. This is the only pushed test:
-  upstream config and ahead/behind counts are a trap (a branch created
-  off origin/develop tracks origin/develop and shows "ahead 1" while
-  never pushed itself).
-- Freshness: remote refs are only as new as the last fetch. Check
-  `stat .git/FETCH_HEAD` on the parent repo; flag stale refs in the
-  plan.
-
-Inside keepers, node_modules / dist / coverage are separately prunable:
-offer cache-prune as the low-risk alternative to removal. Also run
-`git worktree list` on each parent repo - "prunable" entries are stale
-metadata from already-deleted trees.
-
-Done when every candidate carries all four verdicts. The smallest dir
-gets the same triage as the largest: a 4M worktree can hold the only
-copy of uncommitted work.
-
-### 5. Assemble the dry-run plan
-
-- Tier 1 (safe): clean + pushed. Sizes and exact commands.
-- Tier 2 (confirm): pushed branch, dirty only with generated artifacts.
-  Offer full removal and cache-prune-only variants.
-- Keep: unpushed commits or uncommitted diffs. Say exactly what would
-  be lost and suggest pushing the branches.
-- Totals: reclaim per tier.
-
-The plan is pass one's deliverable. Present it and stop - pass two
-starts only from explicit approval, tier by tier.
+Done when every candidate sits in a tier you can defend. Present the
+plan and stop - pass two starts only from explicit approval, tier by
+tier.
 
 ## Pass two: execute approved tiers
 
@@ -97,6 +61,9 @@ starts only from explicit approval, tier by tier.
   only removal path. Its refusal on a dirty tree is the safety net, so
   no --force - and no rm -rf, which bypasses the net and leaves stale
   metadata behind.
+- Tier 2 trees: first delete the named generated files (restore
+  tracked ones with `git checkout --`), so the tree is genuinely clean
+  and the safety net stays armed.
 - Stale metadata: `git -C <parent> worktree prune`.
 - Standalone repos (pushed, clean) and plain dirs: rm -rf.
 
@@ -105,5 +72,4 @@ branch refs live in the parent repo's .git and survive. Committed work
 is never lost - only uncommitted files can be. The metadata edit inside
 the parent's .git is normal bookkeeping, not touching the mount.
 
-Done when df shows the reclaim and `git worktree list` on each parent
-has no leftovers.
+Done when df shows the reclaim and a triage rerun reports empty tiers.

--- a/skills/deva-clean/scripts/triage.sh
+++ b/skills/deva-clean/scripts/triage.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# triage.sh - deva-clean pass one: read-only triage of a deva workspace.
+# Emits a tiered dry-run plan on stdout. Never deletes anything.
+#
+# Usage: triage.sh [WORKSPACE] [--fetch]
+#
+#   WORKSPACE   workspace root (default: current directory)
+#   --fetch     refresh each repo's default branch before the merged
+#               check (writes refs into the repo's .git only; worktrees
+#               and mounts are untouched)
+#
+# Verdicts:
+#   PUSHED-EXACT  remote branch tip == local HEAD (live ls-remote)
+#   MERGED        HEAD is ancestor of origin/<default>; monotonic, so
+#                 provable even against stale refs
+#   LOCAL-ONLY    branch absent on remote, HEAD not in fresh default
+#   UNVERIFIED    branch absent on remote, default ref stale and no
+#                 --fetch: could be recently merged - treat as keep
+#   DIVERGED      remote branch exists but tip differs from HEAD
+#   OFFLINE       ls-remote failed: no live evidence
+#   NO-REMOTE     repo has no origin remote
+set -uo pipefail
+shopt -s nullglob dotglob
+
+WS=$PWD
+DO_FETCH=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fetch) DO_FETCH=1 ;;
+    -h|--help) sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) echo "unknown flag: $1" >&2; exit 2 ;;
+    *) WS=$(cd "$1" && pwd) || exit 2 ;;
+  esac
+  shift
+done
+NET_TIMEOUT=${DEVA_CLEAN_TIMEOUT:-20}
+
+# --- step 1: mount map (ground truth: the kernel, not .deva) ----------
+mapfile -t MOUNTS < <(awk -v ws="$WS" '$2 == ws || index($2, ws"/") == 1 {print $2}' /proc/mounts | sort)
+
+is_mount() {
+  local m
+  for m in "${MOUNTS[@]}"; do [[ $m == "$1" ]] && return 0; done
+  return 1
+}
+
+has_mount_below() {
+  local m
+  for m in "${MOUNTS[@]}"; do [[ $m == "$1"/* ]] && return 0; done
+  return 1
+}
+
+echo "== deva-clean triage: $WS"
+echo "== mounts: ${#MOUNTS[@]} (off limits)"
+is_mount "$WS" || echo "!! workspace root is not a bind mount - is this a deva workspace?"
+
+# --- step 2: locate the pressure --------------------------------------
+echo
+echo "-- pressure"
+df -h / "$WS" | awk 'NR==1 || $NF=="/" || $NF=="'"$WS"'"'
+
+# --- step 3: candidates = non-mount dirs; descend only through dirs
+# --- that still contain mounts beneath them ----------------------------
+CANDIDATES=()
+collect() {
+  local e
+  for e in "$1"/*/; do
+    e=${e%/}
+    [[ ${e##*/} == .git ]] && continue
+    if is_mount "$e"; then continue; fi
+    if has_mount_below "$e"; then collect "$e"; else CANDIDATES+=("$e"); fi
+  done
+}
+collect "$WS"
+
+# --- step 4: four verdicts per candidate -------------------------------
+declare -A DEF_BRANCH FETCH_STATE   # cached per remote URL
+T1=() T2=() KEEP=() JUDGE=()
+T1_KB=0 T2_KB=0
+
+kb() { du -sk "$1" 2>/dev/null | cut -f1; }
+hsize() { echo "$1" | awk '{ if ($1>=1048576) printf "%.1fG", $1/1048576; else if ($1>=1024) printf "%.0fM", $1/1024; else printf "%dK", $1 }'; }
+
+for d in "${CANDIDATES[@]}"; do
+  size_kb=$(kb "$d"); size=$(hsize "$size_kb")
+
+  if [[ -f $d/.git ]]; then type=linked
+  elif [[ -d $d/.git ]]; then type=standalone
+  else JUDGE+=("$size  $d  (no git evidence - judgment call)"); continue; fi
+
+  head=$(git -C "$d" rev-parse HEAD 2>/dev/null) || { KEEP+=("$size  $d  unreadable git state"); continue; }
+  br=$(git -C "$d" rev-parse --abbrev-ref HEAD)
+  porcelain=$(git -C "$d" status --porcelain 2>/dev/null)
+  dirty=0; untracked_only=1
+  while IFS= read -r line; do
+    [[ -z $line ]] && continue
+    dirty=$((dirty + 1))
+    [[ $line == '??'* ]] || untracked_only=0
+  done <<< "$porcelain"
+
+  url=$(git -C "$d" remote get-url origin 2>/dev/null) || url=""
+  verdict=""
+  if [[ -z $url ]]; then
+    verdict=NO-REMOTE
+  else
+    if [[ -z ${DEF_BRANCH[$url]:-} ]]; then
+      DEF_BRANCH[$url]=$(timeout "$NET_TIMEOUT" git -C "$d" ls-remote --symref origin HEAD 2>/dev/null \
+        | awk '$1=="ref:"{sub("refs/heads/","",$2); print $2; exit}')
+    fi
+    def=${DEF_BRANCH[$url]}
+    if [[ -z $def ]]; then
+      verdict=OFFLINE
+    else
+      remote_sha=""
+      [[ $br != HEAD ]] && remote_sha=$(timeout "$NET_TIMEOUT" git -C "$d" ls-remote origin "refs/heads/$br" 2>/dev/null | cut -f1)
+      if [[ -n $remote_sha && $remote_sha == "$head" ]]; then
+        verdict=PUSHED-EXACT
+      else
+        base_ref="" base_note=""
+        if [[ $DO_FETCH == 1 && -z ${FETCH_STATE[$url]:-} ]]; then
+          if timeout $((NET_TIMEOUT * 3)) git -C "$d" fetch origin "$def" >/dev/null 2>&1; then
+            FETCH_STATE[$url]=fresh
+          else FETCH_STATE[$url]=failed; fi
+        fi
+        common=$(git -C "$d" rev-parse --path-format=absolute --git-common-dir)
+        if [[ ${FETCH_STATE[$url]:-} == fresh ]]; then
+          base_ref=FETCH_HEAD base_note=fresh
+        elif git -C "$d" rev-parse -q --verify "origin/$def" >/dev/null 2>&1; then
+          base_ref="origin/$def"
+          base_note="refs from $(stat -c %y "$common/FETCH_HEAD" 2>/dev/null | cut -d' ' -f1 || echo unknown)"
+        fi
+        if [[ -n $base_ref ]] && git -C "$d" merge-base --is-ancestor "$head" "$base_ref" 2>/dev/null; then
+          verdict="MERGED($def,$base_note)"
+        elif [[ -n $remote_sha ]]; then
+          verdict=DIVERGED
+        elif [[ $base_note == fresh ]]; then
+          verdict=LOCAL-ONLY
+        else
+          verdict="UNVERIFIED($base_note; rerun with --fetch)"
+        fi
+      fi
+    fi
+  fi
+
+  row="$size  $d  [$type $br] dirty=$dirty $verdict"
+  case $verdict in
+    PUSHED-EXACT|MERGED*)
+      if [[ $dirty -eq 0 ]]; then
+        if [[ $type == linked ]]; then
+          parent=$(dirname "$(git -C "$d" rev-parse --path-format=absolute --git-common-dir)")
+          T1+=("$row"$'\n'"      \$ git -C $parent worktree remove $d")
+        else
+          T1+=("$row"$'\n'"      \$ rm -rf $d")
+        fi
+        T1_KB=$((T1_KB + size_kb))
+      elif [[ $untracked_only -eq 1 ]]; then
+        T2+=("$row"$'\n'"      untracked: $(echo "$porcelain" | sed 's/^?? //' | head -5 | tr '\n' ' ')")
+        T2_KB=$((T2_KB + size_kb))
+      else
+        KEEP+=("$row - MODIFIED TRACKED FILES (promote to tier 2 only with judgment)")
+      fi ;;
+    *) KEEP+=("$row") ;;
+  esac
+done
+
+# --- stale worktree metadata in mounted parent repos -------------------
+PRUNABLE=()
+for m in "${MOUNTS[@]}"; do
+  [[ -d $m/.git ]] || continue
+  n=$(git -C "$m" worktree list --porcelain 2>/dev/null | grep -c '^prunable') || n=0
+  [[ $n -gt 0 ]] && PRUNABLE+=("$m: $n stale entries -> \$ git -C $m worktree prune")
+done
+
+# --- step 5: the plan ---------------------------------------------------
+section() {
+  echo; echo "-- $1"; shift
+  local x any=0
+  for x in "$@"; do [[ -n $x ]] && { printf '  %s\n' "$x"; any=1; }; done
+  [[ $any -eq 0 ]] && echo "  (none)"
+  return 0
+}
+section "TIER 1: safe (clean + pushed/merged), reclaim ~$(hsize $T1_KB)" "${T1[@]:-}"
+section "TIER 2: confirm (pushed/merged, untracked files only), reclaim ~$(hsize $T2_KB)" "${T2[@]:-}"
+section "KEEP: would lose the only copy" "${KEEP[@]:-}"
+section "JUDGMENT: no git evidence, decide case by case" "${JUDGE[@]:-}"
+section "stale worktree metadata" "${PRUNABLE[@]:-}"
+echo
+echo "== plan only - nothing was deleted. Execution is pass two (see SKILL.md)."


### PR DESCRIPTION
Closes #401

First entry in skills/: a Claude Code skill for cleaning deva workspaces without shooting a mounted repo or unpushed work.

The problem: workspace dirs look identical in ls, but split into .deva bind mounts (live host repos) and local dirs (git worktrees, node_modules, package stores). Agents doing naive disk cleanup rm -rf the wrong thing.

What the skill encodes:
- mount map from /proc/mounts (ground truth, .deva drifts), workspace root itself is a mount
- find the actual disk pressure first: host mount vs container overlay (overlay df lies on shared-VM runtimes)
- git triage per dir: linked worktree vs standalone, dirty state, pushed test via branch -r --contains HEAD (upstream/ahead config is a trap: a branch tracking origin/develop looks tracked while never pushed), FETCH_HEAD freshness
- tiered dry-run report is pass one; deletion is a second, explicitly approved pass
- git worktree remove + prune, never rm -rf on linked worktrees, never --force

Extracted from a real cleanup session that reclaimed ~5G and caught three worktrees holding unpushed branches that upstream config made look safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)