### PR TITLE
fix(build): proxy-aware version resolution and Docker builds, hardened

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # Created by https://www.toptal.com/developers/gitignore/api/node
 # Edit at https://www.toptal.com/developers/gitignore?templates=node
 
-/AGENTS.md
-/.cctrace
 .claude/
 *.bak
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Created by https://www.toptal.com/developers/gitignore/api/node
 # Edit at https://www.toptal.com/developers/gitignore?templates=node
 
+/AGENTS.md
+/.cctrace
 .claude/
 *.bak
 

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,9 @@ SKIP_BUILD_NETWORK_CHECK ?= 0
 # available in all stages without Dockerfile ARG declarations, excluded
 # from cache key so proxy changes don't bust layer cache).
 # Rewrite localhost proxy addresses: 127.0.0.1/localhost on the host is the
-# container's own loopback during build — host.docker.internal reaches the host.
-_dproxy = $(subst ://localhost,://host.docker.internal,$(subst ://127.0.0.1,://host.docker.internal,$1))
+# container's own loopback during build — host.docker.internal reaches the
+# host. The @-patterns catch authenticated proxies (user:pass@127.0.0.1).
+_dproxy = $(subst @localhost,@host.docker.internal,$(subst @127.0.0.1,@host.docker.internal,$(subst ://localhost,://host.docker.internal,$(subst ://127.0.0.1,://host.docker.internal,$1))))
 PROXY_BUILD_ARGS := \
 	$(if $(HTTP_PROXY),--build-arg HTTP_PROXY=$(call _dproxy,$(HTTP_PROXY))) \
 	$(if $(HTTPS_PROXY),--build-arg HTTPS_PROXY=$(call _dproxy,$(HTTPS_PROXY))) \
@@ -57,6 +58,12 @@ PROXY_BUILD_ARGS := \
 	$(if $(https_proxy),--build-arg https_proxy=$(call _dproxy,$(https_proxy))) \
 	$(if $(NO_PROXY),--build-arg NO_PROXY=$(NO_PROXY)) \
 	$(if $(no_proxy),--build-arg no_proxy=$(no_proxy))
+
+# host.docker.internal resolves implicitly on Docker Desktop/OrbStack only;
+# native Linux Engine needs the explicit host-gateway mapping during build.
+ifneq ($(strip $(HTTP_PROXY)$(HTTPS_PROXY)$(http_proxy)$(https_proxy)),)
+PROXY_BUILD_ARGS += --add-host host.docker.internal:host-gateway
+endif
 
 DOCKER_BUILD_FLAGS = $(PROXY_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,22 @@ RUST_TARGETS ?= wasm32-unknown-unknown
 DOCKER_BUILD_EXTRA_ARGS ?=
 SKIP_BUILD_NETWORK_CHECK ?= 0
 
+# Forward host proxy env vars to Docker build (BuildKit predefined ARGs —
+# available in all stages without Dockerfile ARG declarations, excluded
+# from cache key so proxy changes don't bust layer cache).
+# Rewrite localhost proxy addresses: 127.0.0.1/localhost on the host is the
+# container's own loopback during build — host.docker.internal reaches the host.
+_dproxy = $(subst ://localhost,://host.docker.internal,$(subst ://127.0.0.1,://host.docker.internal,$1))
+PROXY_BUILD_ARGS := \
+	$(if $(HTTP_PROXY),--build-arg HTTP_PROXY=$(call _dproxy,$(HTTP_PROXY))) \
+	$(if $(HTTPS_PROXY),--build-arg HTTPS_PROXY=$(call _dproxy,$(HTTPS_PROXY))) \
+	$(if $(http_proxy),--build-arg http_proxy=$(call _dproxy,$(http_proxy))) \
+	$(if $(https_proxy),--build-arg https_proxy=$(call _dproxy,$(https_proxy))) \
+	$(if $(NO_PROXY),--build-arg NO_PROXY=$(NO_PROXY)) \
+	$(if $(no_proxy),--build-arg no_proxy=$(no_proxy))
+
+DOCKER_BUILD_FLAGS = $(PROXY_BUILD_ARGS) $(DOCKER_BUILD_EXTRA_ARGS)
+
 TOOLCHAIN_BUILD_ARGS := \
 	--build-arg NODE_MAJOR=$(NODE_MAJOR) \
 	--build-arg GO_VERSION=$(GO_VERSION) \
@@ -112,7 +128,7 @@ build-network-check:
 		printf '%s\n' \
 			'FROM node:$(NODE_MAJOR)-bookworm-slim' \
 			'RUN node -e "require('\''dns'\'').lookup('\''registry.npmjs.org'\'',{all:true},(e,a)=>{if(e){console.error(e);process.exit(1)};console.log(a.map(x=>x.address).slice(0,3).join('\'','\''))})"' \
-			| docker build $(DOCKER_BUILD_EXTRA_ARGS) --progress=plain --no-cache -f - . >/dev/null; \
+			| docker build $(DOCKER_BUILD_FLAGS) --progress=plain --no-cache -f - . >/dev/null; \
 	fi
 
 build-main: build-network-check
@@ -159,23 +175,23 @@ build-main: build-network-check
 		   fi; \
 		 fi
 	@echo "Hint: override via GO_VERSION=... CLAUDE_CODE_VERSION=... or run 'make versions-pin'"
-	docker build $(DOCKER_BUILD_EXTRA_ARGS) -f $(DOCKERFILE) $(MAIN_BUILD_ARGS) -t $(MAIN_IMAGE) .
+	docker build $(DOCKER_BUILD_FLAGS) -f $(DOCKERFILE) $(MAIN_BUILD_ARGS) -t $(MAIN_IMAGE) .
 	@echo "✅ Build completed: $(MAIN_IMAGE)"
 
 rebuild:
 	@echo "🔨 Rebuilding Docker image (no cache) with $(DOCKERFILE)..."
-	docker build $(DOCKER_BUILD_EXTRA_ARGS) -f $(DOCKERFILE) --no-cache $(MAIN_BUILD_ARGS) -t $(MAIN_IMAGE) .
+	docker build $(DOCKER_BUILD_FLAGS) -f $(DOCKERFILE) --no-cache $(MAIN_BUILD_ARGS) -t $(MAIN_IMAGE) .
 	@echo "✅ Rebuild completed: $(MAIN_IMAGE)"
 
 
 build-core:
 	@echo "🔨 Building stable core image..."
-	docker build $(DOCKER_BUILD_EXTRA_ARGS) -f $(DOCKERFILE) --target agent-base $(CORE_BUILD_ARGS) -t $(CORE_IMAGE) .
+	docker build $(DOCKER_BUILD_FLAGS) -f $(DOCKERFILE) --target agent-base $(CORE_BUILD_ARGS) -t $(CORE_IMAGE) .
 	@echo "✅ Core build completed: $(CORE_IMAGE)"
 
 build-rust-image: build-network-check
 	@echo "🔨 Building Rust Docker image..."
-	docker build $(DOCKER_BUILD_EXTRA_ARGS) -f $(RUST_DOCKERFILE) \
+	docker build $(DOCKER_BUILD_FLAGS) -f $(RUST_DOCKERFILE) \
 		--build-arg BASE_IMAGE=$(CORE_IMAGE) \
 		$(RUST_BUILD_ARGS) \
 		-t $(RUST_IMAGE) .
@@ -192,19 +208,19 @@ build-all:
 
 buildx:
 	@echo "🔨 Building with docker buildx..."
-	docker buildx build -f $(DOCKERFILE) --load $(MAIN_BUILD_ARGS) -t $(MAIN_IMAGE) .
+	docker buildx build $(DOCKER_BUILD_FLAGS) -f $(DOCKERFILE) --load $(MAIN_BUILD_ARGS) -t $(MAIN_IMAGE) .
 	@echo "✅ Buildx completed: $(MAIN_IMAGE)"
 
 buildx-multi:
 	@echo "🔨 Building multi-arch images for amd64 and arm64..."
-	docker buildx build -f $(DOCKERFILE) --platform $(MULTI_ARCH_PLATFORMS) \
+	docker buildx build $(DOCKER_BUILD_FLAGS) -f $(DOCKERFILE) --platform $(MULTI_ARCH_PLATFORMS) \
 		$(MAIN_BUILD_ARGS) \
 		--push -t $(MAIN_IMAGE) .
 	@echo "✅ Multi-arch build completed and pushed: $(MAIN_IMAGE)"
 
 buildx-multi-rust:
 	@echo "🔨 Building multi-arch Rust images for amd64 and arm64..."
-	docker buildx build -f $(RUST_DOCKERFILE) --platform $(MULTI_ARCH_PLATFORMS) \
+	docker buildx build $(DOCKER_BUILD_FLAGS) -f $(RUST_DOCKERFILE) --platform $(MULTI_ARCH_PLATFORMS) \
 		--build-arg BASE_IMAGE=$(MAIN_IMAGE) \
 		$(RUST_BUILD_ARGS) \
 		--push -t $(RUST_IMAGE) .
@@ -212,7 +228,7 @@ buildx-multi-rust:
 
 buildx-multi-local:
 	@echo "🔨 Building multi-arch images locally..."
-	docker buildx build -f $(DOCKERFILE) --platform $(MULTI_ARCH_PLATFORMS) \
+	docker buildx build $(DOCKER_BUILD_FLAGS) -f $(DOCKERFILE) --platform $(MULTI_ARCH_PLATFORMS) \
 		$(MAIN_BUILD_ARGS) \
 		-t $(MAIN_IMAGE) .
 	@echo "✅ Multi-arch build completed locally: $(MAIN_IMAGE)"

--- a/scripts/install-agent-tooling.sh
+++ b/scripts/install-agent-tooling.sh
@@ -119,10 +119,12 @@ download_to() {
 }
 
 log_proxy_config() {
+    # Proxy userinfo is credential material and this output lands in build
+    # logs — redact user:pass@ before printing.
     local has_proxy=0
     for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy NO_PROXY no_proxy; do
         if [ -n "${!var:-}" ]; then
-            log "  $var=${!var}"
+            log "  $var=$(printf '%s' "${!var}" | sed -E 's#://[^@/]*@#://***@#')"
             has_proxy=1
         fi
     done

--- a/scripts/install-agent-tooling.sh
+++ b/scripts/install-agent-tooling.sh
@@ -118,8 +118,23 @@ download_to() {
     curl -fsSL "$url" -o "$dest"
 }
 
+log_proxy_config() {
+    local has_proxy=0
+    for var in HTTP_PROXY HTTPS_PROXY http_proxy https_proxy NO_PROXY no_proxy; do
+        if [ -n "${!var:-}" ]; then
+            log "  $var=${!var}"
+            has_proxy=1
+        fi
+    done
+    if [ "$has_proxy" -eq 0 ]; then
+        log "  (no proxy configured)"
+    fi
+}
+
 install_npm_agent_tooling() {
     log "Installing npm agent tooling"
+    log "Proxy config:"
+    log_proxy_config
     log "Requested versions: claude=${CLAUDE_CODE_VERSION} codex=${CODEX_VERSION} gemini=${GEMINI_CLI_VERSION} grok=${GROK_CLI_VERSION}"
 
     mkdir -p "$DEVA_HOME/.npm-global" "$DEVA_HOME/.local/bin"

--- a/scripts/release-utils.sh
+++ b/scripts/release-utils.sh
@@ -175,6 +175,12 @@ format_datetime() {
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Version Fetching (by type)
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+_npm_registry_latest() {
+    curl -fsSL --max-time 10 \
+        "https://registry.npmjs.org/-/package/$1/dist-tags" 2>/dev/null | \
+        sed -n 's/.*"latest":"\([^"]*\)".*/\1/p'
+}
+
 fetch_latest_version() {
     local tool=$1
     local type=$(get_tool_field "$tool" type)
@@ -182,7 +188,7 @@ fetch_latest_version() {
 
     case $type in
         npm)
-            npm view "$source" version 2>/dev/null || echo ""
+            _npm_registry_latest "$source"
             ;;
         github-release)
             gh api "repos/$source/releases/latest" --jq '.tag_name' 2>/dev/null || echo ""
@@ -203,8 +209,9 @@ fetch_version_date() {
     case $type in
         npm)
             local v=$(normalize_version "$version")
-            npm view "$source@$v" time --json 2>/dev/null | \
-                jq -r --arg ver "$v" '.[$ver] // .' 2>/dev/null | head -1 || echo ""
+            local encoded=${source/\//%2f}
+            curl -fsSL --max-time 10 "https://registry.npmjs.org/$encoded" 2>/dev/null | \
+                jq -r --arg ver "$v" '.time[$ver] // empty' 2>/dev/null | head -1 || echo ""
             ;;
         github-release)
             gh api "repos/$source/releases/tags/$version" --jq '.published_at' 2>/dev/null || echo ""

--- a/scripts/release-utils.sh
+++ b/scripts/release-utils.sh
@@ -188,7 +188,10 @@ fetch_latest_version() {
 
     case $type in
         npm)
-            _npm_registry_latest "$source"
+            # Soft-fail like the gh arms below: a transient registry error
+            # must reach load_versions' warn-and-fallback path, not abort
+            # the whole run under set -e.
+            _npm_registry_latest "$source" || echo ""
             ;;
         github-release)
             gh api "repos/$source/releases/latest" --jq '.tag_name' 2>/dev/null || echo ""

--- a/scripts/update-version-pins.sh
+++ b/scripts/update-version-pins.sh
@@ -21,7 +21,7 @@ EOF
 fetch_npm_version() {
     curl -fsSL --max-time 10 \
         "https://registry.npmjs.org/-/package/$1/dist-tags" 2>/dev/null | \
-        sed -n 's/.*"latest":"\([^"]*\)".*/\1/p'
+        sed -n 's/.*"latest":"\([^"]*\)".*/\1/p' || true
 }
 
 fetch_latest_git_tag() {

--- a/scripts/update-version-pins.sh
+++ b/scripts/update-version-pins.sh
@@ -19,7 +19,9 @@ EOF
 }
 
 fetch_npm_version() {
-    npm view "$1" version 2>/dev/null || true
+    curl -fsSL --max-time 10 \
+        "https://registry.npmjs.org/-/package/$1/dist-tags" 2>/dev/null | \
+        sed -n 's/.*"latest":"\([^"]*\)".*/\1/p'
 }
 
 fetch_latest_git_tag() {

--- a/scripts/version-upgrade.sh
+++ b/scripts/version-upgrade.sh
@@ -32,7 +32,10 @@ CORE_IMAGE=${CORE_IMAGE:-ghcr.io/thevibeworks/deva:core}
 # Forward host proxy env vars to Docker build stages.
 # Rewrite 127.0.0.1/localhost → host.docker.internal so the build
 # container reaches the host's proxy instead of its own loopback.
-_dproxy() { sed 's|://127\.0\.0\.1|://host.docker.internal|g; s|://localhost|://host.docker.internal|g' <<< "$1"; }
+# The @-patterns catch authenticated proxies (user:pass@127.0.0.1).
+_dproxy() { sed 's|://127\.0\.0\.1|://host.docker.internal|g; s|://localhost|://host.docker.internal|g; s|@127\.0\.0\.1|@host.docker.internal|g; s|@localhost|@host.docker.internal|g' <<< "$1"; }
+# Proxy userinfo is credential material — never print it raw.
+_redact_proxy() { sed -E 's#://[^@/]*@#://***@#' <<< "$1"; }
 PROXY_ARGS=()
 [[ -n ${HTTP_PROXY:-} ]]  && PROXY_ARGS+=(--build-arg "HTTP_PROXY=$(_dproxy "$HTTP_PROXY")")
 [[ -n ${HTTPS_PROXY:-} ]] && PROXY_ARGS+=(--build-arg "HTTPS_PROXY=$(_dproxy "$HTTPS_PROXY")")
@@ -40,6 +43,9 @@ PROXY_ARGS=()
 [[ -n ${https_proxy:-} ]] && PROXY_ARGS+=(--build-arg "https_proxy=$(_dproxy "$https_proxy")")
 [[ -n ${NO_PROXY:-} ]]    && PROXY_ARGS+=(--build-arg "NO_PROXY=$NO_PROXY")
 [[ -n ${no_proxy:-} ]]    && PROXY_ARGS+=(--build-arg "no_proxy=$no_proxy")
+# host.docker.internal resolves implicitly on Docker Desktop/OrbStack only;
+# native Linux Engine needs the explicit host-gateway mapping during build.
+[[ ${#PROXY_ARGS[@]} -gt 0 ]] && PROXY_ARGS+=(--add-host "host.docker.internal:host-gateway")
 RUST_IMAGE=${RUST_IMAGE:-ghcr.io/thevibeworks/deva:rust}
 DOCKERFILE=${DOCKERFILE:-Dockerfile}
 RUST_DOCKERFILE=${RUST_DOCKERFILE:-Dockerfile.rust}
@@ -215,7 +221,7 @@ main() {
     if [[ ${#PROXY_ARGS[@]} -gt 0 ]]; then
         echo -e "${DIM}Proxy forwarding to Docker build:${RESET}"
         for _pa in "${PROXY_ARGS[@]}"; do
-            echo -e "  ${DIM}${_pa#--build-arg }${RESET}"
+            echo -e "  ${DIM}$(_redact_proxy "${_pa#--build-arg }")${RESET}"
         done
         echo ""
     fi

--- a/scripts/version-upgrade.sh
+++ b/scripts/version-upgrade.sh
@@ -28,6 +28,18 @@ source "$SCRIPT_DIR/version-pins.sh"
 CHECK_IMAGE=${MAIN_IMAGE:-ghcr.io/thevibeworks/deva:latest}
 BUILD_IMAGE=${BUILD_IMAGE:-ghcr.io/thevibeworks/deva:latest}
 CORE_IMAGE=${CORE_IMAGE:-ghcr.io/thevibeworks/deva:core}
+
+# Forward host proxy env vars to Docker build stages.
+# Rewrite 127.0.0.1/localhost → host.docker.internal so the build
+# container reaches the host's proxy instead of its own loopback.
+_dproxy() { sed 's|://127\.0\.0\.1|://host.docker.internal|g; s|://localhost|://host.docker.internal|g' <<< "$1"; }
+PROXY_ARGS=()
+[[ -n ${HTTP_PROXY:-} ]]  && PROXY_ARGS+=(--build-arg "HTTP_PROXY=$(_dproxy "$HTTP_PROXY")")
+[[ -n ${HTTPS_PROXY:-} ]] && PROXY_ARGS+=(--build-arg "HTTPS_PROXY=$(_dproxy "$HTTPS_PROXY")")
+[[ -n ${http_proxy:-} ]]  && PROXY_ARGS+=(--build-arg "http_proxy=$(_dproxy "$http_proxy")")
+[[ -n ${https_proxy:-} ]] && PROXY_ARGS+=(--build-arg "https_proxy=$(_dproxy "$https_proxy")")
+[[ -n ${NO_PROXY:-} ]]    && PROXY_ARGS+=(--build-arg "NO_PROXY=$NO_PROXY")
+[[ -n ${no_proxy:-} ]]    && PROXY_ARGS+=(--build-arg "no_proxy=$no_proxy")
 RUST_IMAGE=${RUST_IMAGE:-ghcr.io/thevibeworks/deva:rust}
 DOCKERFILE=${DOCKERFILE:-Dockerfile}
 RUST_DOCKERFILE=${RUST_DOCKERFILE:-Dockerfile.rust}
@@ -200,8 +212,17 @@ main() {
     echo -e "${GREEN}Proceeding with build...${RESET}"
     echo ""
 
+    if [[ ${#PROXY_ARGS[@]} -gt 0 ]]; then
+        echo -e "${DIM}Proxy forwarding to Docker build:${RESET}"
+        for _pa in "${PROXY_ARGS[@]}"; do
+            echo -e "  ${DIM}${_pa#--build-arg }${RESET}"
+        done
+        echo ""
+    fi
+
     section "Building Core Image"
     docker build -f "$DOCKERFILE" \
+        ${PROXY_ARGS[@]+"${PROXY_ARGS[@]}"} \
         --target agent-base \
         --build-arg NODE_MAJOR="$NODE_MAJOR" \
         --build-arg GO_VERSION="$GO_VERSION" \
@@ -215,6 +236,7 @@ main() {
     echo ""
     section "Building Main Image"
     docker build -f "$DOCKERFILE" \
+        ${PROXY_ARGS[@]+"${PROXY_ARGS[@]}"} \
         --build-arg NODE_MAJOR="$NODE_MAJOR" \
         --build-arg GO_VERSION="$GO_VERSION" \
         --build-arg PYTHON_VERSION="$PYTHON_VERSION" \
@@ -233,6 +255,7 @@ main() {
     echo ""
     section "Building Rust Image"
     docker build -f "$RUST_DOCKERFILE" \
+        ${PROXY_ARGS[@]+"${PROXY_ARGS[@]}"} \
         --build-arg BASE_IMAGE="$CORE_IMAGE" \
         --build-arg CLAUDE_CODE_VERSION="$claude_ver" \
         --build-arg CCTRACE_VERSION="$cctrace_ver" \

--- a/tests/version-upgrade.sh
+++ b/tests/version-upgrade.sh
@@ -43,57 +43,13 @@ build)
 esac
 EOF
 
+# npm must never be called: version resolution goes straight to the
+# registry via curl. Tripwire catches regressions back to `npm view`
+# (which honors .npmrc registry overrides and can serve stale metadata).
 cat >"$FAKE_BIN/npm" <<'EOF'
 #!/usr/bin/env bash
-set -euo pipefail
-
-if [[ "${1:-}" != "view" ]]; then
-    echo "unexpected npm invocation: $*" >&2
-    exit 1
-fi
-
-case "${2:-}" in
-@anthropic-ai/claude-code)
-    echo "2.1.87"
-    ;;
-@anthropic-ai/claude-code@2.1.87)
-    echo '{"2.1.87":"2026-03-29T01:40:00Z"}'
-    ;;
-@thevibeworks/cctrace)
-    echo "0.4.0"
-    ;;
-@thevibeworks/cctrace@0.4.0)
-    echo '{"0.4.0":"2026-03-29T01:40:00Z"}'
-    ;;
-@openai/codex)
-    echo "0.117.0"
-    ;;
-@openai/codex@0.117.0)
-    echo '{"0.117.0":"2026-03-26T22:28:00Z"}'
-    ;;
-@google/gemini-cli)
-    echo "0.35.3"
-    ;;
-@google/gemini-cli@0.35.3)
-    echo '{"0.35.3":"2026-03-28T03:17:00Z"}'
-    ;;
-@xai-official/grok)
-    echo "0.2.93"
-    ;;
-@xai-official/grok@0.2.93)
-    echo '{"0.2.93":"2026-07-01T00:00:00Z"}'
-    ;;
-playwright)
-    echo "1.60.0"
-    ;;
-playwright@1.60.0)
-    echo '{"1.60.0":"2026-05-14T08:00:00Z"}'
-    ;;
-*)
-    echo "unexpected npm view args: $*" >&2
-    exit 1
-    ;;
-esac
+echo "unexpected npm invocation: $*" >&2
+exit 1
 EOF
 
 cat >"$FAKE_BIN/gh" <<'EOF'
@@ -134,10 +90,31 @@ repos/microsoft/playwright/releases)
 esac
 EOF
 
+# Realistic registry fixtures: dist-tags for fetch_latest_version,
+# packument (.time) for fetch_version_date. Unknown URLs are a hard error
+# so new fetch paths cannot silently no-op like the old empty-string stub.
 cat >"$FAKE_BIN/curl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-printf ''
+url="${!#}"
+case "$url" in
+*/-/package/@anthropic-ai/claude-code/dist-tags) echo '{"latest":"2.1.87"}' ;;
+*/-/package/@thevibeworks/cctrace/dist-tags)     echo '{"latest":"0.4.0"}' ;;
+*/-/package/@openai/codex/dist-tags)             echo '{"latest":"0.117.0"}' ;;
+*/-/package/@google/gemini-cli/dist-tags)        echo '{"latest":"0.35.3"}' ;;
+*/-/package/@xai-official/grok/dist-tags)        echo '{"latest":"0.2.93"}' ;;
+*/-/package/playwright/dist-tags)                echo '{"latest":"1.60.0"}' ;;
+*registry.npmjs.org/@anthropic-ai%2fclaude-code) echo '{"time":{"2.1.87":"2026-03-29T01:40:00Z"}}' ;;
+*registry.npmjs.org/@thevibeworks%2fcctrace)     echo '{"time":{"0.4.0":"2026-03-29T01:40:00Z"}}' ;;
+*registry.npmjs.org/@openai%2fcodex)             echo '{"time":{"0.117.0":"2026-03-26T22:28:00Z"}}' ;;
+*registry.npmjs.org/@google%2fgemini-cli)        echo '{"time":{"0.35.3":"2026-03-28T03:17:00Z"}}' ;;
+*registry.npmjs.org/@xai-official%2fgrok)        echo '{"time":{"0.2.93":"2026-07-01T00:00:00Z"}}' ;;
+*registry.npmjs.org/playwright)                  echo '{"time":{"1.60.0":"2026-05-14T08:00:00Z"}}' ;;
+*)
+    echo "unexpected curl url: $url" >&2
+    exit 1
+    ;;
+esac
 EOF
 
 chmod +x "$FAKE_BIN/docker" "$FAKE_BIN/npm" "$FAKE_BIN/gh" "$FAKE_BIN/curl"
@@ -205,3 +182,78 @@ do
         exit 1
     }
 done
+
+# ───── proxied build: localhost rewrite + host-gateway + redacted logs ─────
+PROXY_BUILD_LOG="$TMP_ROOT/docker-build-proxy.log"
+proxy_out="$(PATH="$FAKE_BIN:$PATH" \
+DOCKER_BUILD_LOG="$PROXY_BUILD_LOG" \
+AUTO_YES=1 \
+HTTP_PROXY="http://user:secret@127.0.0.1:7890" \
+HTTPS_PROXY="http://localhost:7890" \
+CHECK_IMAGE="ghcr.io/thevibeworks/deva:rust" \
+BUILD_IMAGE="ghcr.io/thevibeworks/deva:latest" \
+CORE_IMAGE="ghcr.io/thevibeworks/deva:core" \
+RUST_IMAGE="ghcr.io/thevibeworks/deva:rust" \
+GO_VERSION="1.26.2" \
+CCTRACE_VERSION="0.4.0" \
+PLAYWRIGHT_VERSION="1.60.0" \
+"$REPO_ROOT/scripts/version-upgrade.sh" 2>&1)"
+
+proxy_build="$(sed -n '1p' "$PROXY_BUILD_LOG")"
+for expected in \
+    "--build-arg HTTP_PROXY=http://user:secret@host.docker.internal:7890" \
+    "--build-arg HTTPS_PROXY=http://host.docker.internal:7890" \
+    "--add-host host.docker.internal:host-gateway"
+do
+    [[ "$proxy_build" == *"$expected"* ]] || {
+        echo "proxied build missing expected arg: $expected" >&2
+        echo "$proxy_build" >&2
+        exit 1
+    }
+done
+if grep -F -- "user:secret@" <<<"$proxy_out" >/dev/null; then
+    echo "proxy credentials leaked into script output" >&2
+    exit 1
+fi
+if ! grep -F -- "://***@" <<<"$proxy_out" >/dev/null; then
+    echo "expected redacted proxy URL in script output" >&2
+    exit 1
+fi
+
+# ───── registry outage: warn + fall back to current, do not abort ─────
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+exit 22
+EOF
+chmod +x "$FAKE_BIN/curl"
+
+OUTAGE_BUILD_LOG="$TMP_ROOT/docker-build-outage.log"
+if ! outage_out="$(PATH="$FAKE_BIN:$PATH" \
+DOCKER_BUILD_LOG="$OUTAGE_BUILD_LOG" \
+AUTO_YES=1 \
+CHECK_IMAGE="ghcr.io/thevibeworks/deva:rust" \
+BUILD_IMAGE="ghcr.io/thevibeworks/deva:latest" \
+CORE_IMAGE="ghcr.io/thevibeworks/deva:core" \
+RUST_IMAGE="ghcr.io/thevibeworks/deva:rust" \
+GO_VERSION="1.26.2" \
+CCTRACE_VERSION="0.4.0" \
+PLAYWRIGHT_VERSION="1.60.0" \
+"$REPO_ROOT/scripts/version-upgrade.sh" 2>&1)"; then
+    echo "registry outage must degrade to warnings, not abort the run" >&2
+    echo "$outage_out" >&2
+    exit 1
+fi
+if ! grep -F -- "Failed to fetch latest" <<<"$outage_out" >/dev/null; then
+    echo "expected fetch-failure warnings during outage" >&2
+    echo "$outage_out" >&2
+    exit 1
+fi
+if ! grep -F -- "All versions up-to-date" <<<"$outage_out" >/dev/null; then
+    echo "expected up-to-date fallback conclusion during outage" >&2
+    echo "$outage_out" >&2
+    exit 1
+fi
+if [[ -s "$OUTAGE_BUILD_LOG" ]]; then
+    echo "no builds should run during a registry outage" >&2
+    exit 1
+fi


### PR DESCRIPTION
Re-lands the proxy work split out of #404 (b6360a6), plus the fixes for every gap the review round found there.

Close #407

## What

Original commit, unchanged in intent:
- version resolution: replace `npm view` with direct registry.npmjs.org curl (`npm view` honors `.npmrc` registry overrides, e.g. npmmirror, which can serve stale metadata for recently-republished packages)
- Docker build: forward HTTP(S)_PROXY from host env via BuildKit predefined ARGs; rewrite 127.0.0.1/localhost to host.docker.internal

Hardening on top:
- `--add-host host.docker.internal:host-gateway` on `docker build` whenever proxy args are forwarded — the rewrite was dead on native Linux Engine (Desktop/OrbStack resolve the name implicitly, Engine does not). Verified against a real daemon: flag accepted, name resolves in-build.
- Rewrite catches authenticated proxies: old patterns anchored on `://127.0.0.1` and missed `http://user:pass@127.0.0.1:7890` (confirmed via `make -n`). Both the Make macro and the version-upgrade sed handle `@127.0.0.1`/`@localhost` now.
- Proxy userinfo never printed raw: `log_proxy_config` (lands in docker build logs) and version-upgrade's forwarding display redact `user:pass@` to `***@`. Residual, deliberate: make's own recipe echo still expands proxy values in your local terminal — silencing every build recipe isn't worth it, and CI never carries a localhost proxy.
- npm fetch restores `npm view`'s soft-fail contract: transient curl failure returns empty and reaches `load_versions`' warn-and-fallback branch instead of aborting under `set -euo pipefail` (Copilot's valid half on #404; the URL-encoding half was tested false — both raw and %2f scoped paths return 200).
- Not re-landed: the unrelated `.gitignore` hunk from b6360a6.

## Root cause of the #404 CI red, now covered

The old test's fake curl printed an empty string for every request while stale `npm view` fixtures sat unused: every lookup "failed", the script fell back to image-current versions, decided nothing needed upgrading, exited before any build, and the test died reading the missing docker-build.log.

## Tests

- tests/version-upgrade.sh: realistic dist-tags + packument fixtures; npm mock is now a tripwire (any npm call fails loudly); unknown curl URLs fail loudly instead of silently no-op'ing
- New scenario: proxied build — asserts localhost + authenticated-proxy rewrite, host-gateway flag on the build line, credentials absent (and redacted form present) in script output
- New scenario: registry outage — hard-failing curl produces warnings + fallback to current + exit 0 + zero builds
- Local: full battery green (test_release_utils 58/58, version-upgrade, mount-shape, version-targets, shellcheck severity=error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)