### PR TITLE
feat(tmux): deva-tmux — tmux as a built-in module, both transports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .claude/
 *.bak
 
+/.cctrace
 ### Node ###
 # Logs
 logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `deva-tmux` (#412): tmux interaction is now a built-in module instead of
+  loose scripts. One in-container CLI, two transports — `ssh` (default:
+  authenticated, reboot-durable, runs the host's tmux client so there is
+  no client/server protocol coupling) and `socat` (fallback: the old
+  unauthenticated TCP daemon, kept for hosts without sshd, loud warning
+  every start). Both land the host server on `/tmp/host-tmux.sock`, so
+  `tmux-bridge` (Layer 2) and `htmux` muscle memory work unchanged.
+  Container->host stays opt-in: `deva.sh --host-tmux` mounts `~/.ssh`
+  read-only and passes `DEVA_HOST_USER`; without it the baked CLI is
+  inert. Host-side lifecycle moved where it belongs: `deva.sh tmux setup`
+  authorizes your key by writing your own `authorized_keys` (killing the
+  in-container docker-mount write from the #406 draft), `deva.sh tmux
+  host-daemon start|stop|status` manages the socat fallback, `deva.sh
+  tmux doctor` diagnoses the host side. `deva-bridge-tmux` is now a compat
+  shim. Verified live against a real host: both transports, bridge
+  lifecycle, native client + Layer 2 through the forwarded socket.
+
 ## [0.15.0] - 2026-07-14
 
 ### Added
@@ -59,7 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deva validates and reports the captured credentials (subscription type,
   expiry), or removes the placeholder on abort. Combine with `-Q --rm`
   for a clean one-shot provisioning flow.
-
 ## [0.14.0] - 2026-07-10
 
 ### Added

--- a/DEV-LOGS.md
+++ b/DEV-LOGS.md
@@ -13,6 +13,16 @@
 - Minimal markdown markers, no unnecessary formatting, minimal emojis.
 - Reference issue numbers in the format `#<issue-number>` for easy linking.
 
+# [2026-07-10] Dev Log: deva-tmux — tmux as a built-in module, both transports #412
+- Why: tmux interaction was four loose scripts with zero deva.sh integration; #406 built the right transport (ssh) but deleted the socat fallback and stayed a loose script. Direction split matters: host->container (deva.sh shell) and agent<->agent (tmux-bridge) keep the sandbox; container->host breaks it and must be opt-in.
+- What:
+  - scripts/deva-tmux (new, baked into both images): ls/attach/tmux/bridge/setup/doctor with transport backends — ssh default (authenticated, launchd-durable, host-side tmux client so zero protocol coupling), socat fallback (unauthenticated TCP, warns loudly). DEVA_TMUX_TRANSPORT=auto|ssh|socat; auto probes ssh then socat. Both transports land on /tmp/host-tmux.sock -> tmux-bridge Layer 2 unchanged
+  - inert-without-provisioning is the security property: baked binary + no key + no daemon = no host reach. deva.sh --host-tmux is the opt-in: mounts ~/.ssh ro (dedup-safe, user -v wins), passes DEVA_HOST_USER, launcher's deva-tmux copy overrides the image copy in repo mode (skew insurance)
+  - deva.sh tmux command group (host side): setup writes your OWN authorized_keys — the #406 draft did this from inside the container via a docker host-mount, which is exactly the host-reach pattern the tool exists to gate; moving it host-side dissolved the scariest code. host-daemon start|stop|status wraps the socat daemon (inline fallback when scripts/ absent). doctor for the host view
+  - deva-bridge-tmux -> compat shim (old flags -> env -> deva-tmux bridge start --transport socat --foreground); deva-bridge-tmux-host unchanged; tmux-bridge stays vendored byte-for-byte (read-guard TTL idea goes upstream, not a fork)
+  - found+fixed in live test: backgrounded ssh -N -L inherited the caller's stdout, so `deva-tmux bridge start | tail` hung forever waiting for EOF — the #406 draft had the same latent bug. Bridge children now detach stdio to a state-dir log
+- Result: verified live against a real macOS host from inside the dev container — doctor sees both transports, ssh bridge + socat bridge both land the host server on the socket, native tmux client and tmux-bridge list work through it, lifecycle idempotent, socket cleaned on stop; mount-shape suite asserts off/on/dedup provisioning shapes; shellcheck severity=error clean
+
 # [2026-07-10] Dev Log: repo surface burnish #409
 - Why: product ships four agents but half the storefront said three; agents visiting the repo had no llms.txt; nightly 2026-07-09 failed on a transient ubuntu mirror sync and partially published (base pushed, rust did not — nightly/nightly-rust tags diverged a day)
 - What:

--- a/Dockerfile
+++ b/Dockerfile
@@ -240,12 +240,17 @@ RUN --mount=type=cache,target=/home/deva/.npm,uid=${DEVA_UID},gid=${DEVA_GID},sh
 USER root
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+# deva-tmux: container->host tmux CLI (ssh + socat transports). Baked but
+# inert without host-side provisioning (deva.sh --host-tmux / tmux setup).
+COPY scripts/deva-tmux /usr/local/bin/deva-tmux
+# deva-bridge-tmux: compat shim -> deva-tmux bridge --transport socat
 COPY scripts/deva-bridge-tmux /usr/local/bin/deva-bridge-tmux
 # tmux-bridge: vendored from smux (layer-2 agent comms CLI over tmux panes)
 # See scripts/tmux-bridge.VENDORED for upstream commit and SHA256 pin.
 COPY scripts/tmux-bridge /usr/local/bin/tmux-bridge
 
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/deva-tmux && \
     chmod 755 /usr/local/bin/deva-bridge-tmux && \
     chmod 755 /usr/local/bin/tmux-bridge && \
     chmod -R 755 /usr/local/bin/scripts || true

--- a/Dockerfile.rust
+++ b/Dockerfile.rust
@@ -157,9 +157,14 @@ RUN --mount=type=cache,target=/home/deva/.npm,uid=${DEVA_UID},gid=${DEVA_GID},sh
 USER root
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+# deva-tmux: container->host tmux CLI (ssh + socat transports). Baked but
+# inert without host-side provisioning (deva.sh --host-tmux / tmux setup).
+COPY scripts/deva-tmux /usr/local/bin/deva-tmux
+# deva-bridge-tmux: compat shim -> deva-tmux bridge --transport socat
 COPY scripts/deva-bridge-tmux /usr/local/bin/deva-bridge-tmux
 
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/deva-tmux && \
     chmod 755 /usr/local/bin/deva-bridge-tmux && \
     chmod -R 755 /usr/local/bin/scripts || true
 

--- a/deva.sh
+++ b/deva.sh
@@ -1401,6 +1401,18 @@ tmux_host_setup() {
 # The socat fallback daemon exposes the host tmux socket over TCP with NO
 # authentication — any process that can reach the port drives your tmux.
 # Prefer the ssh transport; this exists for hosts without Remote Login.
+# Stale pidfiles + PID reuse would make us report an unrelated process as
+# our daemon (or kill it on stop); only trust a numeric PID whose command
+# looks like the socat daemon.
+tmux_host_daemon_pid() {
+    local pid_file="$1" pid
+    pid="$(cat "$pid_file" 2>/dev/null)" || return 1
+    case "$pid" in '' | *[!0-9]*) return 1 ;; esac
+    kill -0 "$pid" 2>/dev/null || return 1
+    ps -o command= -p "$pid" 2>/dev/null | grep -qE 'socat|deva-bridge-tmux-host' || return 1
+    echo "$pid"
+}
+
 tmux_host_daemon() {
     local action="${1:-status}"
     local state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/deva/tmux"
@@ -1408,11 +1420,12 @@ tmux_host_daemon() {
     local daemon="$SCRIPT_DIR/scripts/deva-bridge-tmux-host"
     local bind="${DEVA_BRIDGE_BIND:-127.0.0.1}"
     local port="${DEVA_BRIDGE_PORT:-41555}"
+    local pid
 
     case "$action" in
     status)
-        if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
-            echo "host-daemon up (pid $(cat "$pid_file"), ${bind}:${port}) — UNAUTHENTICATED, prefer ssh"
+        if pid=$(tmux_host_daemon_pid "$pid_file"); then
+            echo "host-daemon up (pid $pid, ${bind}:${port}) — UNAUTHENTICATED, prefer ssh"
         else
             echo "host-daemon down"
             return 1
@@ -1420,16 +1433,20 @@ tmux_host_daemon() {
         ;;
     stop)
         if [ -f "$pid_file" ]; then
-            kill "$(cat "$pid_file")" 2>/dev/null || true
+            if pid=$(tmux_host_daemon_pid "$pid_file"); then
+                kill "$pid" 2>/dev/null || true
+                echo "host-daemon stopped"
+            else
+                echo "host-daemon pidfile was stale; cleaned up"
+            fi
             rm -f "$pid_file"
-            echo "host-daemon stopped"
         else
             echo "host-daemon not running"
         fi
         ;;
     start)
-        if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
-            echo "host-daemon already up (pid $(cat "$pid_file"))"
+        if pid=$(tmux_host_daemon_pid "$pid_file"); then
+            echo "host-daemon already up (pid $pid)"
             return 0
         fi
         command -v socat >/dev/null 2>&1 || {

--- a/deva.sh
+++ b/deva.sh
@@ -79,6 +79,7 @@ GLOBAL_MODE=false
 DEBUG_MODE=false
 DRY_RUN=false
 CODEX_BROWSER_MCP=false
+HOST_TMUX=false
 
 if [ -t 0 ] && [ -t 1 ]; then
     DOCKER_TERMINAL_ARGS=(-it)
@@ -120,6 +121,8 @@ Container management commands (docker/tmux-style):
   deva.sh insight [args]      Generate data report (ccx insight pass-through)
   deva.sh ccx [-g] [cmd] [args]
                               Run any ccx command inside a container
+  deva.sh tmux <cmd>         Host-side tmux lifecycle: setup (ssh key),
+                              host-daemon start|stop|status (socat fallback), doctor
 
 Advanced:
   deva.sh --show-config      Show resolved configuration (debug)
@@ -136,6 +139,12 @@ Deva flags:
   -Q, --quick             Bare mode: no host config mounts, no .deva loading, no autolink,
                           implies --rm. Like emacs -Q. Mutually exclusive with -c.
   --host-net              Use host networking for the agent container
+  --host-tmux             Opt in to container->host tmux: mounts ~/.ssh (ro)
+                          and passes DEVA_HOST_USER so the in-container
+                          deva-tmux CLI can reach the host tmux server.
+                          Off by default - it lets the container run
+                          commands on the host. Inside: deva-tmux doctor.
+                          Docs: docs/tmux-bridge-agent-comms.md
   --browser-mcp           Codex only: wire Playwright MCP through Codex config overrides.
                           Uses the rust profile because browser runtime deps live there.
                           Alias: --with-browser
@@ -749,6 +758,30 @@ prepare_claude_chrome_bridge() {
     USER_ENVS+=("DEVA_CHROME_HOST_BRIDGE_DIR=$bridge_mount")
 }
 
+# Container->host tmux is opt-in (--host-tmux). The in-container CLI
+# (deva-tmux) is baked into the image but inert without this provisioning:
+# the ssh transport becomes usable only when the user's ~/.ssh (read-only)
+# and host username ride in. In a repo checkout the launcher's copy of
+# deva-tmux is mounted over the image copy so flag semantics never skew
+# against an older image; installed launchers rely on the image copy.
+prepare_host_tmux() {
+    [ "$HOST_TMUX" = true ] || return 0
+
+    local host_user
+    host_user="$(configured_env_value DEVA_HOST_USER || true)"
+    if [ -z "$host_user" ]; then
+        host_user="$(id -un)"
+    fi
+
+    if [ -d "$HOME/.ssh" ] && ! user_volume_mounts_target "/home/deva/.ssh"; then
+        USER_VOLUMES+=("$HOME/.ssh:/home/deva/.ssh:ro")
+    fi
+    if [ -f "$SCRIPT_DIR/scripts/deva-tmux" ] && ! user_volume_mounts_target "/usr/local/bin/deva-tmux"; then
+        USER_VOLUMES+=("$SCRIPT_DIR/scripts/deva-tmux:/usr/local/bin/deva-tmux:ro")
+    fi
+    USER_ENVS+=("DEVA_HOST_USER=$host_user")
+}
+
 prepare_browser_integration() {
     [ "$CODEX_BROWSER_MCP" = true ] || return 0
 
@@ -1311,6 +1344,181 @@ shorten_path() {
     else
         printf '%s' "$p"
     fi
+}
+
+# --- deva.sh tmux: host-side lifecycle for container->host tmux ------------
+# The container side is deva-tmux (baked into the image, inert without
+# provisioning). The host side owns exactly what must not be done from
+# inside the sandbox: authorizing the ssh key and running the socat daemon.
+
+tmux_host_setup() {
+    local marker="deva-host-tmux"
+    local pub=""
+    for k in "$HOME/.ssh/id_ed25519.pub" "$HOME/.ssh/id_rsa.pub"; do
+        [ -f "$k" ] && { pub="$k"; break; }
+    done
+    if [ -z "$pub" ]; then
+        echo "error: no ssh keypair found in ~/.ssh" >&2
+        echo "generate one first:  ssh-keygen -t ed25519" >&2
+        echo "then re-run:         deva.sh tmux setup" >&2
+        return 1
+    fi
+
+    mkdir -p "$HOME/.ssh"
+    touch "$HOME/.ssh/authorized_keys"
+    chmod 600 "$HOME/.ssh/authorized_keys"
+    local pubkey
+    pubkey="$(cat "$pub")"
+    if grep -qF "$pubkey" "$HOME/.ssh/authorized_keys"; then
+        echo "ok: key already authorized ($pub)"
+    else
+        printf '%s %s\n' "$pubkey" "$marker" >>"$HOME/.ssh/authorized_keys"
+        echo "ok: key authorized ($pub)"
+        echo "undo: remove the '$marker' line from ~/.ssh/authorized_keys"
+    fi
+
+    if timeout 3 bash -c 'exec 3<>/dev/tcp/127.0.0.1/22' 2>/dev/null; then
+        echo "ok: sshd is listening on port 22"
+    else
+        echo "warning: sshd is not reachable on 127.0.0.1:22" >&2
+        echo "macOS: System Settings > General > Sharing > Remote Login" >&2
+        echo "       or: sudo systemsetup -setremotelogin on" >&2
+        return 1
+    fi
+    echo "container side: deva.sh --host-tmux <agent>, then: deva-tmux doctor"
+}
+
+# The socat fallback daemon exposes the host tmux socket over TCP with NO
+# authentication — any process that can reach the port drives your tmux.
+# Prefer the ssh transport; this exists for hosts without Remote Login.
+tmux_host_daemon() {
+    local action="${1:-status}"
+    local state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/deva/tmux"
+    local pid_file="$state_dir/host-daemon.pid"
+    local daemon="$SCRIPT_DIR/scripts/deva-bridge-tmux-host"
+    local bind="${DEVA_BRIDGE_BIND:-127.0.0.1}"
+    local port="${DEVA_BRIDGE_PORT:-41555}"
+
+    case "$action" in
+    status)
+        if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+            echo "host-daemon up (pid $(cat "$pid_file"), ${bind}:${port}) — UNAUTHENTICATED, prefer ssh"
+        else
+            echo "host-daemon down"
+            return 1
+        fi
+        ;;
+    stop)
+        if [ -f "$pid_file" ]; then
+            kill "$(cat "$pid_file")" 2>/dev/null || true
+            rm -f "$pid_file"
+            echo "host-daemon stopped"
+        else
+            echo "host-daemon not running"
+        fi
+        ;;
+    start)
+        if [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+            echo "host-daemon already up (pid $(cat "$pid_file"))"
+            return 0
+        fi
+        command -v socat >/dev/null 2>&1 || {
+            echo "error: socat not installed on host" >&2
+            return 1
+        }
+        local socket
+        socket="$(tmux display-message -p '#{socket_path}' 2>/dev/null || true)"
+        [ -n "$socket" ] || socket="/private/tmp/tmux-$(id -u)/default"
+        if [ ! -S "$socket" ]; then
+            echo "error: no host tmux server socket at $socket (start tmux first)" >&2
+            return 1
+        fi
+        echo "WARNING: exposing host tmux over UNAUTHENTICATED ${bind}:${port}" >&2
+        echo "         any local process gains tmux control; prefer: deva.sh tmux setup" >&2
+        mkdir -p "$state_dir"
+        if [ -x "$daemon" ]; then
+            nohup "$daemon" -q -b "$bind" -p "$port" -s "$socket" >>"$state_dir/host-daemon.log" 2>&1 &
+        else
+            # Installed launcher without the repo's scripts/: same mechanics inline.
+            nohup socat "TCP-LISTEN:${port},bind=${bind},reuseaddr,fork" "UNIX-CONNECT:${socket}" >>"$state_dir/host-daemon.log" 2>&1 &
+        fi
+        echo $! >"$pid_file"
+        sleep 0.3
+        if kill -0 "$(cat "$pid_file")" 2>/dev/null; then
+            echo "host-daemon up (pid $(cat "$pid_file"), ${bind}:${port} -> ${socket})"
+            echo "container side: deva-tmux bridge start --transport socat"
+        else
+            rm -f "$pid_file"
+            echo "error: host-daemon failed to start (see $state_dir/host-daemon.log)" >&2
+            return 1
+        fi
+        ;;
+    *)
+        echo "error: unknown host-daemon action: $action (start|stop|status)" >&2
+        return 1
+        ;;
+    esac
+}
+
+tmux_host_doctor() {
+    echo "deva tmux doctor (host side)"
+    echo "---"
+    local pub=""
+    for k in "$HOME/.ssh/id_ed25519.pub" "$HOME/.ssh/id_rsa.pub"; do
+        [ -f "$k" ] && { pub="$k"; break; }
+    done
+    if [ -n "$pub" ]; then
+        echo "ssh keypair:     $pub"
+        if [ -f "$HOME/.ssh/authorized_keys" ] && grep -qF "$(cat "$pub")" "$HOME/.ssh/authorized_keys"; then
+            echo "authorized:      yes"
+        else
+            echo "authorized:      NO (run: deva.sh tmux setup)"
+        fi
+    else
+        echo "ssh keypair:     NONE (ssh-keygen -t ed25519)"
+    fi
+    if timeout 3 bash -c 'exec 3<>/dev/tcp/127.0.0.1/22' 2>/dev/null; then
+        echo "sshd port 22:    open"
+    else
+        echo "sshd port 22:    CLOSED (macOS: Sharing > Remote Login)"
+    fi
+    local sessions
+    sessions="$(tmux ls 2>/dev/null | wc -l | tr -d ' ')"
+    echo "tmux sessions:   $sessions"
+    tmux_host_daemon status || true
+    echo "---"
+    echo "container side:  deva.sh --host-tmux <agent>, then deva-tmux doctor"
+}
+
+cmd_tmux() {
+    local sub="${1:-help}"
+    [ $# -gt 0 ] && shift
+    case "$sub" in
+    setup) tmux_host_setup "$@" ;;
+    host-daemon) tmux_host_daemon "${1:-status}" ;;
+    doctor) tmux_host_doctor ;;
+    help | -h | --help)
+        cat <<'EOF'
+deva.sh tmux - host-side lifecycle for container->host tmux
+
+Usage:
+  deva.sh tmux setup                          Authorize your ssh key (ssh transport, default)
+  deva.sh tmux host-daemon start|stop|status  socat fallback daemon (UNAUTHENTICATED)
+  deva.sh tmux doctor                         Host-side diagnosis
+
+Container side:
+  deva.sh --host-tmux <agent>                 Opt-in provisioning at launch
+  deva-tmux ls|attach|bridge|doctor           In-container CLI (both transports)
+  tmux-bridge list|read|type|...              Agent<->agent pane comms (Layer 2)
+
+Docs: docs/tmux-bridge-agent-comms.md
+EOF
+        ;;
+    *)
+        echo "error: unknown tmux subcommand: $sub (setup|host-daemon|doctor|help)" >&2
+        exit 1
+        ;;
+    esac
 }
 
 cmd_status() {
@@ -2898,6 +3106,11 @@ parse_wrapper_args() {
             i=$((i + 1))
             continue
             ;;
+        --host-tmux)
+            HOST_TMUX=true
+            i=$((i + 1))
+            continue
+            ;;
         --rm)
             EPHEMERAL_MODE=true
             i=$((i + 1))
@@ -3018,7 +3231,14 @@ if [ ${#PRE_ARGS[@]} -gt 0 ]; then
     done
 fi
 
-if [ ${#PRE_ARGS[@]} -gt 0 ]; then
+# `deva.sh tmux <sub> [args]` is a command group: only the FIRST token
+# selects it, so subcommand args (status, stop, ...) can't collide with the
+# management-mode tokens scanned below.
+if [ "${PRE_ARGS[0]:-}" = "tmux" ]; then
+    MANAGEMENT_MODE="tmux"
+fi
+
+if [ ${#PRE_ARGS[@]} -gt 0 ] && [ "$MANAGEMENT_MODE" != "tmux" ]; then
     for tok in "${PRE_ARGS[@]}"; do
         case "$tok" in
         help | --help | -h)
@@ -3065,6 +3285,11 @@ if [ ${#PRE_ARGS[@]} -gt 0 ]; then
 fi
 
 if [ "$MANAGEMENT_MODE" != "launch" ]; then
+    if [ "$MANAGEMENT_MODE" = "tmux" ]; then
+        cmd_tmux "${PRE_ARGS[@]:1}"
+        exit $?
+    fi
+
     if [ "$MANAGEMENT_MODE" = "ps" ]; then
         list_containers_pretty
         exit 0
@@ -3387,6 +3612,7 @@ autolink_legacy_into_deva_root() {
 check_agent "$ACTIVE_AGENT"
 prepare_browser_integration
 prepare_claude_chrome_bridge
+prepare_host_tmux
 append_shared_agents_mount
 
 if [ -n "$CONFIG_HOME" ] && [ "$DRY_RUN" != true ]; then

--- a/deva.sh
+++ b/deva.sh
@@ -1351,6 +1351,16 @@ shorten_path() {
 # provisioning). The host side owns exactly what must not be done from
 # inside the sandbox: authorizing the ssh key and running the socat daemon.
 
+# Stock macOS ships no `timeout`; probe with nc (present there) and fall
+# back to /dev/tcp, which fails fast on a refused localhost connect.
+tmux_host_port22_open() {
+    if command -v nc >/dev/null 2>&1; then
+        nc -z -w 2 127.0.0.1 22 2>/dev/null
+    else
+        (exec 3<>/dev/tcp/127.0.0.1/22) 2>/dev/null
+    fi
+}
+
 tmux_host_setup() {
     local marker="deva-host-tmux"
     local pub=""
@@ -1377,7 +1387,7 @@ tmux_host_setup() {
         echo "undo: remove the '$marker' line from ~/.ssh/authorized_keys"
     fi
 
-    if timeout 3 bash -c 'exec 3<>/dev/tcp/127.0.0.1/22' 2>/dev/null; then
+    if tmux_host_port22_open; then
         echo "ok: sshd is listening on port 22"
     else
         echo "warning: sshd is not reachable on 127.0.0.1:22" >&2
@@ -1477,7 +1487,7 @@ tmux_host_doctor() {
     else
         echo "ssh keypair:     NONE (ssh-keygen -t ed25519)"
     fi
-    if timeout 3 bash -c 'exec 3<>/dev/tcp/127.0.0.1/22' 2>/dev/null; then
+    if tmux_host_port22_open; then
         echo "sshd port 22:    open"
     else
         echo "sshd port 22:    CLOSED (macOS: Sharing > Remote Login)"

--- a/deva.sh
+++ b/deva.sh
@@ -1011,7 +1011,7 @@ build_container_name() {
     local agent_seg="$agent"
     local agent_ver
     agent_ver="$(agent_version_tag "$agent")"
-    [ -n "$agent_ver" ] && agent_seg="${agent}-v${agent_ver}"
+    [ -n "$agent_ver" ] && agent_seg="${agent}v${agent_ver}"
 
     local name="${prefix}--${agent_seg}--${auth_tag}--${slug}..${shape_hash}"
     if [ "$ephemeral" = true ] && [ -n "$pid" ]; then
@@ -1152,8 +1152,8 @@ extract_agent_from_name() {
     local name="$1"
     local rest="${name#"${DEVA_CONTAINER_PREFIX}"}"
 
-    # New format: deva--<agent>[-v<version>]--<auth>--<slug>..<hash>
-    if [[ "$rest" =~ ^--([a-z]+)(-v[A-Za-z0-9._-]+)?-- ]]; then
+    # New format: deva--<agent>[v<version>]--<auth>--<slug>..<hash>
+    if [[ "$rest" =~ ^--([a-z]+)(v[A-Za-z0-9._-]+)?-- ]]; then
         printf '%s' "${BASH_REMATCH[1]}"
         return
     fi

--- a/docs/tmux-bridge-agent-comms.md
+++ b/docs/tmux-bridge-agent-comms.md
@@ -1,37 +1,73 @@
-# tmux-bridge: agent-to-agent comms in deva containers
+# tmux in deva: directions, transports, layers
 
-deva ships two tmux bridge layers. They compose.
+deva treats tmux interaction as three directions with different trust
+shapes. Only one of them crosses the sandbox boundary, and that one is
+opt-in.
 
-    Layer 1  deva-bridge-tmux       kernel boundary
-             (scripts/deva-bridge-tmux)   container tmux client -> host tmux server
-             socat TCP tunnel             via host.docker.internal:41555
+    Direction           tool             sandbox
+    ---------           ----             -------
+    host -> container   deva.sh shell    intact — default, recommended
+                        (docker exec)    host reaches in, container gains nothing
+    agent <-> agent     tmux-bridge      intact — panes inside one server
+    container -> host   deva-tmux        OPT-IN (--host-tmux) — container can
+                                         run commands on the host
 
-    Layer 2  tmux-bridge             semantic CLI
-             (scripts/tmux-bridge)         read/type/keys/label/envelope
-             vendored from smux           for agents to drive each other's panes
+Two layers compose on top of that:
 
-Layer 1 is the plumbing that lets the container see host tmux at all. Layer 2
-is what agents actually call.
+    Layer 1  deva-tmux        transport: gets the container a connection
+             (in the image)   to the host tmux server (ssh or socat)
 
-## Security
+    Layer 2  tmux-bridge      semantics: read/type/keys/label/envelope
+             (in the image)   for agents to drive each other's panes
 
-Both layers are privileged host bridges. If you run them, the container can
-execute arbitrary commands on the host tmux server (send-keys, run-shell,
-scrollback). This is deliberate for trusted dev workflows. Do not enable on
-untrusted code.
+Layer 2 does not care which transport carried the socket. Both transports
+land the host server on the same path: `/tmp/host-tmux.sock`.
 
-## Quick start
+## Transports
 
-Host (macOS):
+`deva-tmux` speaks two transports and picks automatically (ssh first):
 
-    deva-bridge-tmux-host                 # expose host tmux over TCP:41555
+| | ssh (default) | socat (fallback) |
+|---|---|---|
+| Auth | your ssh key, mounted read-only | **none — any local process connects** |
+| Survives host reboot | yes (sshd is launchd-managed) | no (daemon must be restarted) |
+| tmux protocol coupling | none for ls/attach/tmux (host client runs) | container client must match host server |
+| Host prerequisite | Remote Login enabled + `deva.sh tmux setup` | `deva.sh tmux host-daemon start` |
 
-Container (inside a deva agent):
+Force one with `DEVA_TMUX_TRANSPORT=ssh|socat`. The socat transport prints
+a loud warning every time — it exists for hosts that cannot enable sshd,
+not as a peer of the ssh path.
 
-    deva-bridge-tmux                      # start socat; creates /tmp/host-tmux.sock
-    tmux -S /tmp/host-tmux.sock attach    # optional: attach to host session
+## Quick start: container -> host
 
-From another pane (or the same container, any agent CLI that can shell out):
+Host side, once:
+
+    deva.sh tmux setup             # authorize your ssh key (prints undo)
+
+Launch with provisioning (this is the opt-in):
+
+    deva.sh --host-tmux claude
+
+Inside the container:
+
+    deva-tmux doctor               # layer-by-layer check of both transports
+    deva-tmux ls                   # host sessions (host-side tmux client)
+    deva-tmux attach [session]     # interactive attach over ssh
+    deva-tmux tmux kill-session -t foo    # host tmux passthrough
+
+Or land the host server on a local socket for native tools and Layer 2:
+
+    deva-tmux bridge start         # /tmp/host-tmux.sock (0600)
+    tmux -S /tmp/host-tmux.sock attach
+    TMUX_BRIDGE_SOCKET=/tmp/host-tmux.sock tmux-bridge list
+    deva-tmux bridge stop
+
+Without `--host-tmux`, `deva-tmux` is inert: the ssh backend has no key to
+use and the socat backend has no daemon to reach. That is the point.
+
+## Quick start: agent <-> agent
+
+Inside any tmux server (a container session, or a bridged host server):
 
     tmux-bridge list                      # see all panes
     tmux-bridge name %1 planner           # label a pane
@@ -40,7 +76,26 @@ From another pane (or the same container, any agent CLI that can shell out):
     tmux-bridge type planner "rerun tests"
     tmux-bridge keys planner Enter
 
-## Socket detection
+## Security
+
+Container -> host is a privileged direction: whoever holds it can
+send-keys, run-shell, and read scrollback on your host tmux server. deva's
+posture:
+
+- Off by default. `--host-tmux` is the only thing that provisions it, and
+  it mounts your `~/.ssh` read-only — no key ever gets written from inside
+  a container. Key authorization happens on the host (`deva.sh tmux
+  setup`), where writing your own `authorized_keys` is a normal operation
+  instead of a sandbox escape.
+- The ssh transport is authenticated and scoped to key holders. The socat
+  transport is not: the host daemon exposes tmux over TCP with no auth,
+  which is why it is the fallback, warns on every start, and binds
+  127.0.0.1 unless you explicitly widen it.
+- A container holding the docker socket already has an equivalent write
+  path to the host; `--host-tmux` does not mount it and `deva-tmux`
+  refuses to use it.
+
+## Socket detection (Layer 2)
 
 `tmux-bridge` auto-detects the tmux server socket in this order:
 
@@ -49,12 +104,11 @@ From another pane (or the same container, any agent CLI that can shell out):
 3. Scan `/tmp/tmux-<uid>/*` for a server that owns `$TMUX_PANE`
 4. Default tmux server
 
-For deva containers talking to host tmux via the layer-1 bridge, attach to
-tmux first (step 2 fires) or set the override:
+For a bridged host server, set the override:
 
     export TMUX_BRIDGE_SOCKET=/tmp/host-tmux.sock
 
-## Read-before-act guard
+## Read-before-act guard (Layer 2)
 
 `tmux-bridge` enforces that agents `read` a pane before they can `type`,
 `message`, or `keys` into it. This is the main safety net against "agent
@@ -69,17 +123,31 @@ it; any write clears it. So the contract is:
 
 ## Diagnostics
 
-    tmux-bridge doctor
+    deva-tmux doctor        # container side: both transports, bridge, Layer 2
+    deva.sh tmux doctor     # host side: key, sshd, daemon, sessions
+    tmux-bridge doctor      # Layer 2: socket detection, pane visibility
 
-Prints env vars, detected socket, visible panes, and a pass/fail summary.
-Run this first when things go wrong.
+Run the one closest to where things are failing.
+
+## Compatibility
+
+- `deva-bridge-tmux` still works: it is now a shim for
+  `deva-tmux bridge start --transport socat --foreground`, preserving the
+  old flags and foreground semantics.
+- `deva-bridge-tmux-host` is unchanged and managed by
+  `deva.sh tmux host-daemon start|stop|status`.
+- `DEVA_BRIDGE_HOST/PORT/SOCK` are still honored; new knobs live under
+  `DEVA_TMUX_*`.
 
 ## Provenance
 
 `scripts/tmux-bridge` is vendored byte-for-byte from upstream smux
 (github.com/ShawnPana/smux). See `scripts/tmux-bridge.VENDORED` for the
 pinned commit and SHA256. License is MIT, reproduced in
-`scripts/THIRD_PARTY_LICENSES/smux-LICENSE`.
+`scripts/THIRD_PARTY_LICENSES/smux-LICENSE`. Improvements we want (e.g. a
+TTL on the read guard) go upstream, not into a local fork.
 
-`scripts/deva-bridge-tmux` and `scripts/deva-bridge-tmux-host` are deva's
-own work (see `docs/devlog/20260108-deva-bridge-tmux.org`).
+`scripts/deva-tmux`, `scripts/deva-bridge-tmux`, and
+`scripts/deva-bridge-tmux-host` are deva's own work (see
+`docs/devlog/20260108-deva-bridge-tmux.org` and issue #412 for the design
+history, including the ssh transport from #405/#406).

--- a/scripts/deva-bridge-tmux
+++ b/scripts/deva-bridge-tmux
@@ -20,10 +20,12 @@ Prefer: deva-tmux bridge start   (auto-selects ssh when provisioned)
 EOF
 }
 
+QUIET=0
+
 while [ $# -gt 0 ]; do
     case $1 in
     -h | --help) usage; exit 0 ;;
-    -q | --quiet) ;;
+    -q | --quiet) QUIET=1 ;;
     -H | --host)
         [ $# -ge 2 ] || { echo "$prog: missing value for $1" >&2; exit 1; }
         DEVA_BRIDGE_HOST="$2"; export DEVA_BRIDGE_HOST; shift ;;
@@ -38,4 +40,9 @@ while [ $# -gt 0 ]; do
     shift
 done
 
+# -q matched the old script's behavior: info lines suppressed, warnings
+# and errors still on stderr.
+if [ "$QUIET" -eq 1 ]; then
+    exec deva-tmux bridge start --transport socat --foreground >/dev/null
+fi
 exec deva-tmux bridge start --transport socat --foreground

--- a/scripts/deva-bridge-tmux
+++ b/scripts/deva-bridge-tmux
@@ -21,10 +21,14 @@ EOF
 }
 
 QUIET=0
+VERSION="1.0.0"
 
+# Same option surface as the old script: -V/--version, -- ends options,
+# non-option args are ignored (break), only unknown -flags error.
 while [ $# -gt 0 ]; do
     case $1 in
     -h | --help) usage; exit 0 ;;
+    -V | --version) printf '%s %s (deva-tmux shim)\n' "$prog" "$VERSION"; exit 0 ;;
     -q | --quiet) QUIET=1 ;;
     -H | --host)
         [ $# -ge 2 ] || { echo "$prog: missing value for $1" >&2; exit 1; }
@@ -35,7 +39,9 @@ while [ $# -gt 0 ]; do
     -s | --socket)
         [ $# -ge 2 ] || { echo "$prog: missing value for $1" >&2; exit 1; }
         DEVA_TMUX_SOCK="$2"; export DEVA_TMUX_SOCK; shift ;;
-    *) echo "$prog: unknown option: $1" >&2; exit 1 ;;
+    --) shift; break ;;
+    -*) echo "$prog: unknown option: $1" >&2; exit 1 ;;
+    *) break ;;
     esac
     shift
 done

--- a/scripts/deva-bridge-tmux
+++ b/scripts/deva-bridge-tmux
@@ -1,151 +1,41 @@
 #!/bin/sh
-# shellcheck shell=sh
-# Version: 0.3.0
-#
-# deva-bridge-tmux - Container-side tmux bridge for deva
-#
-# Connect container tmux client to host tmux server via TCP bridge.
-# Requires deva-bridge-tmux-host running on the macOS host.
-#
-# SECURITY WARNING:
-#   This is a PRIVILEGED HOST BRIDGE. Container gains full tmux control.
-#   Effectively a sandbox escape - container can run commands on host.
-
+# deva-bridge-tmux — compat shim. The socat container side moved into
+# deva-tmux (one CLI, ssh + socat transports); this preserves the old
+# flags and foreground semantics for muscle memory and existing docs.
 set -eu
-umask 077
 
 prog=${0##*/}
-VERSION=0.3.0
-
-EXIT_OK=0
-EXIT_ERROR=1
-EXIT_NOTFOUND=3
-
-QUIET=0
-HOST="${DEVA_BRIDGE_HOST:-host.docker.internal}"
-PORT="${DEVA_BRIDGE_PORT:-41555}"
-LOCAL_SOCK="${DEVA_BRIDGE_SOCK:-/tmp/host-tmux.sock}"
-
-# --- util ---
-
-log() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
-warn() { printf '%s\n' "$*" >&2; }
-err() { printf '%s\n' "$*" >&2; }
-die() { err "$prog: error: $*"; exit "$EXIT_ERROR"; }
 
 usage() {
-  cat <<EOF
-$prog - container-side tmux bridge for deva
+    cat <<EOF
+$prog - compat shim for 'deva-tmux bridge start --transport socat --foreground'
 
-USAGE:
-  $prog [OPTIONS]
-
-OPTIONS:
+OPTIONS (mapped to deva-tmux env):
   -H, --host HOST   host address (default: host.docker.internal)
   -p, --port PORT   TCP port (default: 41555)
   -s, --socket PATH local socket path (default: /tmp/host-tmux.sock)
-  -q, --quiet       suppress non-error output
   -h, --help        show this help
-  -V, --version     show version
 
-ENV:
-  DEVA_BRIDGE_HOST  host address (default: host.docker.internal)
-  DEVA_BRIDGE_PORT  TCP port (default: 41555)
-  DEVA_BRIDGE_SOCK  local socket (default: /tmp/host-tmux.sock)
-
-SECURITY:
-  This is a PRIVILEGED HOST BRIDGE. Container gains full tmux control.
-  You can send-keys, run-shell, read scrollback on host tmux sessions.
-
-PREREQUISITES:
-  On macOS host, run: deva-bridge-tmux-host
-
-EXAMPLES:
-  $prog
-  tmux -S /tmp/host-tmux.sock list-sessions
-  tmux -S /tmp/host-tmux.sock attach -t WIP
-
-TIP:
-  alias htmux='tmux -S /tmp/host-tmux.sock'
+Prefer: deva-tmux bridge start   (auto-selects ssh when provisioned)
 EOF
 }
 
-version() { printf '%s %s\n' "$prog" "$VERSION"; }
-
-require() {
-  command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1"
-}
-
-check_host_reachable() {
-  # Try nc first, fall back to socat probe
-  if command -v nc >/dev/null 2>&1; then
-    nc -z -w2 "$HOST" "$PORT" 2>/dev/null && return 0
-  fi
-  # Fallback: socat probe (timeout 1s)
-  socat -T1 /dev/null "TCP:$HOST:$PORT" 2>/dev/null && return 0
-  return 1
-}
-
-# --- parse options ---
-
 while [ $# -gt 0 ]; do
-  case $1 in
-    -h|--help) usage; exit "$EXIT_OK" ;;
-    -V|--version) version; exit "$EXIT_OK" ;;
-    -q|--quiet) QUIET=1 ;;
-    -H|--host)
-      [ $# -ge 2 ] || die "missing value for $1"
-      HOST="$2"; shift ;;
-    -p|--port)
-      [ $# -ge 2 ] || die "missing value for $1"
-      PORT="$2"; shift ;;
-    -s|--socket)
-      [ $# -ge 2 ] || die "missing value for $1"
-      LOCAL_SOCK="$2"; shift ;;
-    --) shift; break ;;
-    -*) die "unknown option: $1" ;;
-    *) break ;;
-  esac
-  shift
+    case $1 in
+    -h | --help) usage; exit 0 ;;
+    -q | --quiet) ;;
+    -H | --host)
+        [ $# -ge 2 ] || { echo "$prog: missing value for $1" >&2; exit 1; }
+        DEVA_BRIDGE_HOST="$2"; export DEVA_BRIDGE_HOST; shift ;;
+    -p | --port)
+        [ $# -ge 2 ] || { echo "$prog: missing value for $1" >&2; exit 1; }
+        DEVA_BRIDGE_PORT="$2"; export DEVA_BRIDGE_PORT; shift ;;
+    -s | --socket)
+        [ $# -ge 2 ] || { echo "$prog: missing value for $1" >&2; exit 1; }
+        DEVA_TMUX_SOCK="$2"; export DEVA_TMUX_SOCK; shift ;;
+    *) echo "$prog: unknown option: $1" >&2; exit 1 ;;
+    esac
+    shift
 done
 
-# --- main ---
-
-main() {
-  require socat
-  require tmux
-
-  # Verify host reachable
-  if ! check_host_reachable; then
-    err "$prog: cannot reach $HOST:$PORT"
-    err ""
-    err "on macOS host, run:"
-    err "  deva-bridge-tmux-host"
-    err ""
-    err "if host.docker.internal can't reach 127.0.0.1, try:"
-    err "  deva-bridge-tmux-host --bind 0.0.0.0"
-    exit "$EXIT_NOTFOUND"
-  fi
-
-  # Remove stale socket; socat uses unlink-early so no cleanup needed after exec
-  rm -f "$LOCAL_SOCK"
-
-  warn "============================================"
-  warn "WARNING: PRIVILEGED HOST BRIDGE (tmux)"
-  warn "============================================"
-  warn "Container can execute commands on host via tmux."
-  warn ""
-
-  log "deva bridge: tmux (container-side)"
-  log "  host: $HOST:$PORT"
-  log "  sock: $LOCAL_SOCK"
-  log ""
-  log "usage: tmux -S $LOCAL_SOCK list-sessions"
-  log "tip:   alias htmux='tmux -S $LOCAL_SOCK'"
-
-  exec socat \
-    "UNIX-LISTEN:$LOCAL_SOCK,fork,unlink-early" \
-    "TCP:$HOST:$PORT"
-}
-
-main "$@"
+exec deva-tmux bridge start --transport socat --foreground

--- a/scripts/deva-tmux
+++ b/scripts/deva-tmux
@@ -150,8 +150,20 @@ EOF
     exit 1
 }
 
+# A pidfile can go stale and the PID be reused by an unrelated process;
+# only treat it as ours if it is numeric AND the command looks like our
+# transport child (ssh or socat).
+bridge_pid_ours() {
+    local pid
+    pid=$(cat "$BRIDGE_PID" 2>/dev/null) || return 1
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    ps -o command= -p "$pid" 2>/dev/null | grep -qE '(^|/| )(ssh|socat) ' || return 1
+    echo "$pid"
+}
+
 bridge_alive() {
-    [[ -S "$BRIDGE_SOCK" && -f "$BRIDGE_PID" ]] && kill -0 "$(cat "$BRIDGE_PID")" 2>/dev/null
+    [[ -S "$BRIDGE_SOCK" && -f "$BRIDGE_PID" ]] && bridge_pid_ours >/dev/null
 }
 
 usage() {
@@ -329,9 +341,14 @@ cmd_bridge() {
         ;;
     stop)
         if [[ -f "$BRIDGE_PID" ]]; then
-            kill "$(cat "$BRIDGE_PID")" 2>/dev/null || true
+            local pid
+            if pid=$(bridge_pid_ours); then
+                kill "$pid" 2>/dev/null || true
+                echo "bridge stopped"
+            else
+                echo "bridge pidfile was stale; cleaned up"
+            fi
             rm -f "$BRIDGE_PID" "$BRIDGE_SOCK"
-            echo "bridge stopped"
         else
             echo "bridge not running"
         fi

--- a/scripts/deva-tmux
+++ b/scripts/deva-tmux
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+# deva-tmux — reach the host machine's tmux from inside a deva container.
+#
+# One CLI, two transports:
+#
+#   ssh    (default)  authenticated, launchd-durable on macOS, and runs the
+#                     HOST's tmux client for ls/attach/tmux — zero
+#                     client/server protocol coupling.
+#   socat  (fallback) plain TCP to a host-side daemon (deva-bridge-tmux-host,
+#                     port 41555). Unauthenticated — any local process on the
+#                     host network can drive your tmux. Kept for hosts
+#                     without sshd; the warning is loud on purpose.
+#
+# Both transports land the host tmux server on the SAME local socket
+# (/tmp/host-tmux.sock), so tmux-bridge (Layer 2) and `htmux` muscle memory
+# work unchanged whichever transport carried it.
+#
+# SECURITY: container -> host is a privileged direction; this tool is baked
+# into the image but INERT without host-side provisioning. The ssh backend
+# needs a key you mount (deva.sh --host-tmux mounts ~/.ssh read-only); the
+# socat backend needs a daemon you start on the host (deva.sh tmux
+# host-daemon start). No provisioning, no host reach.
+set -euo pipefail
+
+VERSION="1.0.0"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/deva-tmux"
+KNOWN_HOSTS="$STATE_DIR/known_hosts"
+BRIDGE_SOCK="${DEVA_TMUX_SOCK:-${DEVA_BRIDGE_SOCK:-/tmp/host-tmux.sock}}"
+BRIDGE_PID="$STATE_DIR/bridge.pid"
+TRANSPORT="${DEVA_TMUX_TRANSPORT:-auto}"
+
+# socat backend endpoint (deva-bridge-tmux-host on the host side)
+SOCAT_HOST="${DEVA_BRIDGE_HOST:-host.docker.internal}"
+SOCAT_PORT="${DEVA_BRIDGE_PORT:-41555}"
+
+# --- ssh transport -----------------------------------------------------------
+
+# ~/.ssh is usually the host's, mounted read-only, so known_hosts lives in
+# the state dir. -F none skips host ssh config that references host-only
+# paths. BatchMode everywhere except attach: agents call this, and a password
+# prompt that never returns is the worst failure mode.
+SSH_OPTS=(
+    -F none
+    -o "UserKnownHostsFile=$KNOWN_HOSTS"
+    -o StrictHostKeyChecking=accept-new
+    -o ServerAliveInterval=30
+    -o ConnectTimeout=8
+)
+
+hssh() {
+    mkdir -p "$STATE_DIR"
+    ssh -o BatchMode=yes "${SSH_OPTS[@]}" "$@"
+}
+
+# DEVA_HOST_SSH overrides everything (full user@host). Otherwise the user
+# comes from DEVA_HOST_USER (deva.sh --host-tmux sets it) or the chrome
+# bridge var deva already exports; the host is docker's name for the machine.
+host_target() {
+    if [[ -n "${DEVA_HOST_SSH:-}" ]]; then
+        echo "$DEVA_HOST_SSH"
+        return
+    fi
+    local user="${DEVA_HOST_USER:-${DEVA_CHROME_HOST_USER:-}}"
+    [[ -n "$user" ]] || return 1
+    [[ "$user" =~ ^[A-Za-z0-9._-]+$ ]] || die "bogus host user: $user"
+    echo "${user}@host.docker.internal"
+}
+
+ssh_ok() {
+    local target
+    target=$(host_target 2>/dev/null) || return 1
+    hssh "$target" true 2>/dev/null
+}
+
+# Non-interactive ssh runs the user's login shell, which may not be POSIX;
+# wrap probes in sh -c so fish/nushell users don't get parse errors.
+host_tmux_bin() {
+    local probe='for t in "$(command -v tmux)" /opt/homebrew/bin/tmux /usr/local/bin/tmux /usr/bin/tmux; do [ -x "$t" ] && { echo "$t"; exit; }; done; exit 1'
+    hssh "$(host_target)" "sh -c '$probe'" ||
+        die "tmux not found on host ($(host_target))"
+}
+
+host_tmux_socket() {
+    local bin="$1"
+    hssh "$(host_target)" "sh -c '$bin display-message -p \"#{socket_path}\" 2>/dev/null || echo /tmp/tmux-\$(id -u)/default'"
+}
+
+# --- socat transport ---------------------------------------------------------
+
+socat_reachable() {
+    if command -v nc >/dev/null 2>&1; then
+        nc -z -w2 "$SOCAT_HOST" "$SOCAT_PORT" 2>/dev/null && return 0
+    fi
+    if command -v socat >/dev/null 2>&1; then
+        socat -T1 /dev/null "TCP:$SOCAT_HOST:$SOCAT_PORT" 2>/dev/null && return 0
+    fi
+    return 1
+}
+
+socat_warning() {
+    cat >&2 <<'EOF'
+============================================
+WARNING: socat transport is UNAUTHENTICATED
+============================================
+Any process that can reach the host daemon's TCP port gains full tmux
+control on the host (send-keys, run-shell, scrollback). Prefer the ssh
+transport: deva.sh tmux setup (host) + deva.sh --host-tmux (launch).
+EOF
+}
+
+# --- transport resolution ----------------------------------------------------
+
+resolve_transport() {
+    case "$TRANSPORT" in
+    ssh | socat)
+        echo "$TRANSPORT"
+        return
+        ;;
+    auto) ;;
+    *) die "unknown transport: $TRANSPORT (auto|ssh|socat)" ;;
+    esac
+
+    if ssh_ok; then
+        echo "ssh"
+        return
+    fi
+    if socat_reachable; then
+        echo "socat"
+        return
+    fi
+
+    cat >&2 <<EOF
+error: no usable transport to the host tmux server.
+
+  ssh:   $(host_target 2>/dev/null || echo "<no host user; deva.sh --host-tmux sets DEVA_HOST_USER>") — auth failed or unreachable.
+         Host side: deva.sh tmux setup    Container side: needs ~/.ssh mounted (deva.sh --host-tmux)
+  socat: $SOCAT_HOST:$SOCAT_PORT — daemon not reachable.
+         Host side: deva.sh tmux host-daemon start
+
+Run 'deva-tmux doctor' for a layer-by-layer diagnosis.
+EOF
+    exit 1
+}
+
+bridge_alive() {
+    [[ -S "$BRIDGE_SOCK" && -f "$BRIDGE_PID" ]] && kill -0 "$(cat "$BRIDGE_PID")" 2>/dev/null
+}
+
+usage() {
+    cat <<'EOF'
+deva-tmux — drive the host machine's tmux from inside a deva container
+
+Usage: deva-tmux <command> [args...]
+
+Commands:
+  ls                     List host tmux sessions
+  attach [session]       Attach; with a name, create it if missing
+  tmux <args...>         Host tmux passthrough (e.g. deva-tmux tmux kill-session -t foo)
+  bridge [start|stop|status] [--transport ssh|socat] [--foreground]
+                         Land the host tmux server on /tmp/host-tmux.sock, then:
+                           tmux -S /tmp/host-tmux.sock attach
+                           TMUX_BRIDGE_SOCKET=/tmp/host-tmux.sock tmux-bridge list
+  setup                  Verify ssh transport prerequisites (key + auth)
+  doctor                 Diagnose both transports layer by layer
+  version                Print version
+
+Transports:
+  ssh (default)          authenticated; host-side tmux client, no protocol coupling
+  socat (fallback)       unauthenticated TCP to deva-bridge-tmux-host:41555
+
+Environment:
+  DEVA_TMUX_TRANSPORT    auto (default) | ssh | socat
+  DEVA_TMUX_SOCK         local bridge socket (default: /tmp/host-tmux.sock)
+  DEVA_HOST_SSH          full ssh override, e.g. me@host.docker.internal
+  DEVA_HOST_USER         host username (deva.sh --host-tmux sets this)
+  DEVA_BRIDGE_HOST/PORT  socat daemon endpoint (default: host.docker.internal:41555)
+EOF
+    exit 0
+}
+
+# --- commands ----------------------------------------------------------------
+
+cmd_ls() {
+    local transport
+    transport=$(resolve_transport)
+    if [[ "$transport" == "ssh" ]]; then
+        local bin
+        bin=$(host_tmux_bin)
+        hssh "$(host_target)" "$bin ls"
+    else
+        ensure_bridge socat
+        tmux -S "$BRIDGE_SOCK" ls
+    fi
+}
+
+cmd_attach() {
+    [[ -t 0 ]] || die "attach needs a tty; use 'deva-tmux tmux ...' instead"
+    local transport
+    transport=$(resolve_transport)
+    if [[ "$transport" == "ssh" ]]; then
+        local bin cmd="attach"
+        bin=$(host_tmux_bin)
+        [[ -n "${1:-}" ]] && cmd="new-session -A -s $(printf '%q' "$1")"
+        mkdir -p "$STATE_DIR"
+        exec ssh -t "${SSH_OPTS[@]}" "$(host_target)" "$bin $cmd"
+    else
+        ensure_bridge socat
+        if [[ -n "${1:-}" ]]; then
+            exec tmux -S "$BRIDGE_SOCK" new-session -A -s "$1"
+        fi
+        exec tmux -S "$BRIDGE_SOCK" attach
+    fi
+}
+
+cmd_tmux() {
+    [[ $# -ge 1 ]] || die "'tmux' needs arguments"
+    local transport
+    transport=$(resolve_transport)
+    if [[ "$transport" == "ssh" ]]; then
+        local bin
+        bin=$(host_tmux_bin)
+        hssh "$(host_target)" "$bin $(printf '%q ' "$@")"
+    else
+        ensure_bridge socat
+        tmux -S "$BRIDGE_SOCK" "$@"
+    fi
+}
+
+# Start the bridge if it is not already up (used by socat-mode commands that
+# need the local socket as their only path to the server).
+ensure_bridge() {
+    bridge_alive && return 0
+    bridge_start "$1" false
+}
+
+bridge_start() {
+    local transport="$1" foreground="$2"
+
+    if bridge_alive; then
+        echo "bridge already up: $BRIDGE_SOCK"
+        return 0
+    fi
+    mkdir -p "$STATE_DIR"
+    rm -f "$BRIDGE_SOCK"
+
+    if [[ "$transport" == "ssh" ]]; then
+        local bin remote_sock
+        bin=$(host_tmux_bin)
+        remote_sock=$(host_tmux_socket "$bin")
+        [[ -n "$remote_sock" ]] || die "cannot determine host tmux socket path"
+        if [[ "$foreground" == true ]]; then
+            echo "bridge (ssh, foreground): $BRIDGE_SOCK -> $(host_target):$remote_sock"
+            exec ssh -o BatchMode=yes "${SSH_OPTS[@]}" -N -L "$BRIDGE_SOCK:$remote_sock" "$(host_target)"
+        fi
+        # Detach stdio: an inherited stdout keeps callers' pipes open forever.
+        ssh -o BatchMode=yes "${SSH_OPTS[@]}" -N -L "$BRIDGE_SOCK:$remote_sock" "$(host_target)" \
+            >>"$STATE_DIR/bridge.log" 2>&1 </dev/null &
+        echo $! >"$BRIDGE_PID"
+    else
+        command -v socat >/dev/null 2>&1 || die "missing dependency: socat"
+        socat_reachable || {
+            echo "error: cannot reach $SOCAT_HOST:$SOCAT_PORT" >&2
+            echo "on the host, run: deva.sh tmux host-daemon start" >&2
+            exit 3
+        }
+        socat_warning
+        if [[ "$foreground" == true ]]; then
+            echo "bridge (socat, foreground): $BRIDGE_SOCK -> $SOCAT_HOST:$SOCAT_PORT"
+            exec socat "UNIX-LISTEN:$BRIDGE_SOCK,fork,unlink-early,mode=600" "TCP:$SOCAT_HOST:$SOCAT_PORT"
+        fi
+        socat "UNIX-LISTEN:$BRIDGE_SOCK,fork,unlink-early,mode=600" "TCP:$SOCAT_HOST:$SOCAT_PORT" \
+            >>"$STATE_DIR/bridge.log" 2>&1 </dev/null &
+        echo $! >"$BRIDGE_PID"
+    fi
+
+    local i
+    for i in 1 2 3 4 5; do
+        [[ -S "$BRIDGE_SOCK" ]] && break
+        sleep 0.4
+    done
+    [[ -S "$BRIDGE_SOCK" ]] || {
+        rm -f "$BRIDGE_PID"
+        die "bridge failed to come up"
+    }
+    echo "bridge up ($transport): $BRIDGE_SOCK"
+    echo "usage: tmux -S $BRIDGE_SOCK attach"
+    echo "       TMUX_BRIDGE_SOCKET=$BRIDGE_SOCK tmux-bridge list"
+}
+
+cmd_bridge() {
+    local action="start" foreground=false transport=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        start | stop | status) action="$1" ;;
+        --foreground) foreground=true ;;
+        --transport)
+            [[ $# -ge 2 ]] || die "missing value for --transport"
+            transport="$2"
+            shift
+            ;;
+        *) die "unknown bridge argument: $1 (start|stop|status, --transport, --foreground)" ;;
+        esac
+        shift
+    done
+
+    case "$action" in
+    status)
+        if bridge_alive; then
+            echo "bridge up: $BRIDGE_SOCK (pid $(cat "$BRIDGE_PID"))"
+        else
+            echo "bridge down"
+            return 1
+        fi
+        ;;
+    stop)
+        if [[ -f "$BRIDGE_PID" ]]; then
+            kill "$(cat "$BRIDGE_PID")" 2>/dev/null || true
+            rm -f "$BRIDGE_PID" "$BRIDGE_SOCK"
+            echo "bridge stopped"
+        else
+            echo "bridge not running"
+        fi
+        ;;
+    start)
+        if [[ -z "$transport" ]]; then
+            transport=$(resolve_transport)
+        fi
+        case "$transport" in ssh | socat) ;; *) die "unknown transport: $transport" ;; esac
+        bridge_start "$transport" "$foreground"
+        ;;
+    esac
+}
+
+# In-container setup only VERIFIES the ssh path — writing the host's
+# authorized_keys from inside the sandbox would need the docker socket,
+# which is exactly the kind of host reach this tool refuses to normalize.
+# The write happens on the host: deva.sh tmux setup.
+cmd_setup() {
+    local target
+    target=$(host_target 2>/dev/null) ||
+        die "no host user; launch with 'deva.sh --host-tmux' (sets DEVA_HOST_USER) or set it manually"
+
+    if ssh_ok; then
+        echo "ok: ssh to $target works — nothing to do"
+        return
+    fi
+
+    local pub=""
+    for k in "$HOME/.ssh/id_ed25519.pub" "$HOME/.ssh/id_rsa.pub"; do
+        [[ -f "$k" ]] && { pub="$k"; break; }
+    done
+    if [[ -z "$pub" ]]; then
+        echo "no pubkey visible in ~/.ssh — launch with 'deva.sh --host-tmux' to mount it (read-only)" >&2
+    else
+        echo "pubkey present ($pub) but ssh auth failed." >&2
+    fi
+    echo "on the HOST, run: deva.sh tmux setup" >&2
+    echo "then re-check here: deva-tmux doctor" >&2
+    exit 1
+}
+
+cmd_doctor() {
+    echo "deva-tmux doctor v${VERSION}"
+    echo "transport policy:  $TRANSPORT"
+    echo "bridge socket:     $BRIDGE_SOCK"
+    echo "---"
+
+    # ssh transport
+    local target
+    if target=$(host_target 2>/dev/null); then
+        echo "ssh target:        $target"
+        if getent hosts "${target#*@}" >/dev/null 2>&1; then
+            echo "ssh resolution:    ok"
+            if timeout 3 bash -c "exec 3<>/dev/tcp/${target#*@}/22" 2>/dev/null; then
+                echo "ssh port 22:       open"
+                if ssh_ok; then
+                    echo "ssh auth:          ok"
+                    local bin
+                    if bin=$(host_tmux_bin 2>/dev/null); then
+                        echo "host tmux:         $bin"
+                        echo "host sessions:     $(hssh "$target" "$bin ls 2>/dev/null | wc -l" | tr -d ' ')"
+                    else
+                        echo "host tmux:         NOT FOUND on host"
+                    fi
+                else
+                    echo "ssh auth:          FAILED (host side: deva.sh tmux setup)"
+                fi
+            else
+                echo "ssh port 22:       CLOSED (macOS: System Settings > Sharing > Remote Login)"
+            fi
+        else
+            echo "ssh resolution:    FAILED (${target#*@} does not resolve)"
+        fi
+    else
+        echo "ssh target:        unset (deva.sh --host-tmux sets DEVA_HOST_USER)"
+    fi
+    echo "---"
+
+    # socat transport
+    echo "socat endpoint:    $SOCAT_HOST:$SOCAT_PORT"
+    if socat_reachable; then
+        echo "socat daemon:      reachable (UNAUTHENTICATED transport — prefer ssh)"
+    else
+        echo "socat daemon:      not reachable (host side: deva.sh tmux host-daemon start)"
+    fi
+    echo "---"
+
+    # local state
+    if bridge_alive; then
+        echo "bridge:            up ($BRIDGE_SOCK, pid $(cat "$BRIDGE_PID"))"
+        if command -v tmux >/dev/null 2>&1 && tmux -S "$BRIDGE_SOCK" ls >/dev/null 2>&1; then
+            echo "bridge server:     responding"
+        else
+            echo "bridge server:     socket up but tmux not responding through it"
+        fi
+    else
+        echo "bridge:            down (optional; deva-tmux bridge start)"
+    fi
+    if command -v tmux-bridge >/dev/null 2>&1; then
+        echo "layer 2:           tmux-bridge present ($(tmux-bridge version 2>/dev/null || echo '?'))"
+    else
+        echo "layer 2:           tmux-bridge NOT in PATH"
+    fi
+    echo "---"
+
+    local usable
+    usable=$(resolve_transport 2>/dev/null || echo "none")
+    if [[ "$usable" == "none" ]]; then
+        echo "status: NO USABLE TRANSPORT"
+        return 1
+    fi
+    echo "status: OK (would use: $usable)"
+}
+
+# --- main --------------------------------------------------------------------
+
+[[ $# -eq 0 ]] && usage
+
+case "$1" in
+ls) shift; cmd_ls "$@" ;;
+attach | a) shift; cmd_attach "$@" ;;
+tmux) shift; cmd_tmux "$@" ;;
+bridge) shift; cmd_bridge "$@" ;;
+setup) shift; cmd_setup "$@" ;;
+doctor) shift; cmd_doctor "$@" ;;
+version) echo "deva-tmux $VERSION" ;;
+-h | --help | help) usage ;;
+*) die "unknown command: $1. Run 'deva-tmux' for usage." ;;
+esac

--- a/scripts/deva-tmux
+++ b/scripts/deva-tmux
@@ -83,9 +83,14 @@ host_tmux_bin() {
         die "tmux not found on host ($(host_target))"
 }
 
+# Remote invocations pass the tmux path (and args) as positionals to a
+# fixed `sh -c` script: the login shell only ever parses quoted words, and
+# sh — not zsh/fish — does the expansion. No exec before a || fallback:
+# a successful exec would make the fallback unreachable.
 host_tmux_socket() {
     local bin="$1"
-    hssh "$(host_target)" "sh -c '$bin display-message -p \"#{socket_path}\" 2>/dev/null || echo /tmp/tmux-\$(id -u)/default'"
+    hssh "$(host_target)" \
+        "sh -c '\"\$0\" display-message -p \"#{socket_path}\" 2>/dev/null || echo /tmp/tmux-\$(id -u)/default' $(printf '%q' "$bin")"
 }
 
 # --- socat transport ---------------------------------------------------------
@@ -189,7 +194,7 @@ cmd_ls() {
     if [[ "$transport" == "ssh" ]]; then
         local bin
         bin=$(host_tmux_bin)
-        hssh "$(host_target)" "$bin ls"
+        hssh "$(host_target)" "sh -c 'exec \"\$0\" ls' $(printf '%q' "$bin")"
     else
         ensure_bridge socat
         tmux -S "$BRIDGE_SOCK" ls
@@ -201,11 +206,14 @@ cmd_attach() {
     local transport
     transport=$(resolve_transport)
     if [[ "$transport" == "ssh" ]]; then
-        local bin cmd="attach"
+        local bin
         bin=$(host_tmux_bin)
-        [[ -n "${1:-}" ]] && cmd="new-session -A -s $(printf '%q' "$1")"
         mkdir -p "$STATE_DIR"
-        exec ssh -t "${SSH_OPTS[@]}" "$(host_target)" "$bin $cmd"
+        if [[ -n "${1:-}" ]]; then
+            exec ssh -t "${SSH_OPTS[@]}" "$(host_target)" \
+                "sh -c 'exec \"\$0\" new-session -A -s \"\$1\"' $(printf '%q ' "$bin" "$1")"
+        fi
+        exec ssh -t "${SSH_OPTS[@]}" "$(host_target)" "sh -c 'exec \"\$0\" attach' $(printf '%q' "$bin")"
     else
         ensure_bridge socat
         if [[ -n "${1:-}" ]]; then
@@ -222,7 +230,7 @@ cmd_tmux() {
     if [[ "$transport" == "ssh" ]]; then
         local bin
         bin=$(host_tmux_bin)
-        hssh "$(host_target)" "$bin $(printf '%q ' "$@")"
+        hssh "$(host_target)" "sh -c 'exec \"\$0\" \"\$@\"' $(printf '%q ' "$bin" "$@")"
     else
         ensure_bridge socat
         tmux -S "$BRIDGE_SOCK" "$@"

--- a/scripts/deva-tmux
+++ b/scripts/deva-tmux
@@ -259,6 +259,10 @@ bridge_start() {
         bin=$(host_tmux_bin)
         remote_sock=$(host_tmux_socket "$bin")
         [[ -n "$remote_sock" ]] || die "cannot determine host tmux socket path"
+        # Forwarding to a missing remote socket "succeeds" and then every
+        # connection through it fails opaquely — verify the server first.
+        hssh "$(host_target)" "sh -c 'test -S \"\$0\"' $(printf '%q' "$remote_sock")" ||
+            die "no host tmux server socket at $remote_sock — start one on the host: tmux new -d"
         if [[ "$foreground" == true ]]; then
             echo "bridge (ssh, foreground): $BRIDGE_SOCK -> $(host_target):$remote_sock"
             exec ssh -o BatchMode=yes "${SSH_OPTS[@]}" -N -L "$BRIDGE_SOCK:$remote_sock" "$(host_target)"
@@ -389,7 +393,7 @@ cmd_doctor() {
                     local bin
                     if bin=$(host_tmux_bin 2>/dev/null); then
                         echo "host tmux:         $bin"
-                        echo "host sessions:     $(hssh "$target" "$bin ls 2>/dev/null | wc -l" | tr -d ' ')"
+                        echo "host sessions:     $(hssh "$target" "sh -c '\"\$0\" ls 2>/dev/null | wc -l' $(printf '%q' "$bin")" | tr -d ' ')"
                     else
                         echo "host tmux:         NOT FOUND on host"
                     fi

--- a/scripts/test-container-slug.sh
+++ b/scripts/test-container-slug.sh
@@ -194,7 +194,7 @@ docker() {
 AGENT_VERSION_TAG_CACHE_AGENT="" AGENT_VERSION_TAG_CACHE=""
 name=$(build_container_name "deva" "claude" "auth-file-max" "myrepo" "ab12cd34" "false" "")
 assert_eq "persistent with agent version" \
-    "deva--claude-v2.1.204--auth-file-max--myrepo..ab12cd34" "$name"
+    "deva--claudev2.1.204--auth-file-max--myrepo..ab12cd34" "$name"
 
 AGENT_VERSION_TAG_CACHE_AGENT="" AGENT_VERSION_TAG_CACHE=""
 name=$(build_container_name "deva" "mystery" "auth-default" "myrepo" "ab12cd34" "false" "")
@@ -220,10 +220,10 @@ assert_eq "new format ephemeral" "claude" \
     "$(extract_agent_from_name "deva--claude--api-key-abcd--myrepo..ab12cd34--99999")"
 
 assert_eq "versioned agent segment" "claude" \
-    "$(extract_agent_from_name "deva--claude-v2.1.204--auth-file-max--myrepo..ab12cd34")"
+    "$(extract_agent_from_name "deva--claudev2.1.204--auth-file-max--myrepo..ab12cd34")"
 
 assert_eq "versioned ephemeral" "codex" \
-    "$(extract_agent_from_name "deva--codex-v0.131.0--auth-default--myrepo..ab12cd34--4242")"
+    "$(extract_agent_from_name "deva--codexv0.131.0--auth-default--myrepo..ab12cd34--4242")"
 
 assert_eq "legacy ephemeral" "claude" \
     "$(extract_agent_from_name "deva-myrepo..i47b207-claude-12345")"
@@ -285,7 +285,7 @@ out="$(run_dry claude --debug --dry-run || true)"
 cname="$(extract_container_name "$out")"
 if [ -n "$cname" ]; then
     assert_match "dry-run: new format structure" \
-        "^deva--claude(-v[A-Za-z0-9._-]+)?--auth-default--" "$cname"
+        "^deva--claude(v[A-Za-z0-9._-]+)?--auth-default--" "$cname"
     assert_match "dry-run: ends with ..hash" \
         '\.\.[a-f0-9]{8}$' "$cname"
     assert_no_match "dry-run: no old-style ..i prefix" \
@@ -298,7 +298,7 @@ out="$(run_dry codex --debug --dry-run || true)"
 cname="$(extract_container_name "$out")"
 if [ -n "$cname" ]; then
     assert_match "dry-run codex: agent in name" \
-        "^deva--codex(-v[A-Za-z0-9._-]+)?--" "$cname"
+        "^deva--codex(v[A-Za-z0-9._-]+)?--" "$cname"
 else
     fail "dry-run codex: could not extract container name"
 fi
@@ -307,7 +307,7 @@ out="$(run_dry gemini --debug --dry-run || true)"
 cname="$(extract_container_name "$out")"
 if [ -n "$cname" ]; then
     assert_match "dry-run gemini: agent in name" \
-        "^deva--gemini(-v[A-Za-z0-9._-]+)?--" "$cname"
+        "^deva--gemini(v[A-Za-z0-9._-]+)?--" "$cname"
 else
     fail "dry-run gemini: could not extract container name"
 fi
@@ -319,7 +319,7 @@ if [ -n "$cname" ]; then
     assert_match "dry-run ephemeral: has PID suffix" \
         '--[0-9]+$' "$cname"
     assert_match "dry-run ephemeral: agent in name" \
-        "^deva--claude(-v[A-Za-z0-9._-]+)?--" "$cname"
+        "^deva--claude(v[A-Za-z0-9._-]+)?--" "$cname"
 else
     fail "dry-run ephemeral: could not extract container name"
 fi

--- a/scripts/test-mount-shape.sh
+++ b/scripts/test-mount-shape.sh
@@ -211,6 +211,55 @@ if grep -F -- "--tmpfs /home/deva/.grok/bin:" <<<"$apikey_out" >/dev/null; then
     exit 1
 fi
 
+# ───── --host-tmux provisioning coverage ─────
+# Container->host tmux is opt-in: no flag, no ~/.ssh mount, no host user env.
+# With the flag: ~/.ssh rides in read-only exactly once (user -v wins), and
+# DEVA_HOST_USER is passed for the in-container deva-tmux CLI.
+
+mkdir -p "$default_root/home/.ssh"
+
+plain_out="$(run_default claude --dry-run || true)"
+if [[ "$(count_target /home/deva/.ssh "$plain_out")" -ne 0 ]]; then
+    echo "host-tmux off: /home/deva/.ssh mounted without --host-tmux" >&2
+    echo "$plain_out" >&2
+    exit 1
+fi
+if grep -F -- "DEVA_HOST_USER=" <<<"$plain_out" >/dev/null; then
+    echo "host-tmux off: DEVA_HOST_USER passed without --host-tmux" >&2
+    echo "$plain_out" >&2
+    exit 1
+fi
+
+tmuxon_out="$(run_default claude --host-tmux --dry-run || true)"
+if [[ "$(count_target /home/deva/.ssh "$tmuxon_out")" -ne 1 ]]; then
+    echo "host-tmux on: /home/deva/.ssh not mounted exactly once" >&2
+    echo "$tmuxon_out" >&2
+    exit 1
+fi
+if ! grep -F -- "$default_root/home/.ssh:/home/deva/.ssh:ro" <<<"$tmuxon_out" >/dev/null; then
+    echo "host-tmux on: ~/.ssh mount is not read-only" >&2
+    echo "$tmuxon_out" >&2
+    exit 1
+fi
+if ! grep -F -- "DEVA_HOST_USER=" <<<"$tmuxon_out" >/dev/null; then
+    echo "host-tmux on: DEVA_HOST_USER not passed" >&2
+    echo "$tmuxon_out" >&2
+    exit 1
+fi
+
+mkdir -p "$default_root/cli-ssh"
+tmuxdedup_out="$(run_default claude --host-tmux --dry-run -v "$default_root/cli-ssh:/home/deva/.ssh" || true)"
+if [[ "$(count_target /home/deva/.ssh "$tmuxdedup_out")" -ne 1 ]]; then
+    echo "host-tmux dedup: /home/deva/.ssh emitted more than once with user -v" >&2
+    echo "$tmuxdedup_out" >&2
+    exit 1
+fi
+if ! grep -F -- "-v $default_root/cli-ssh:/home/deva/.ssh" <<<"$tmuxdedup_out" >/dev/null; then
+    echo "host-tmux dedup: user -v for /home/deva/.ssh did not win" >&2
+    echo "$tmuxdedup_out" >&2
+    exit 1
+fi
+
 # Explicit --config-home DIR isolates to a single home (no sibling agents).
 iso_out="$(run_default claude --config-home "$default_root/xdg/deva/claude" --dry-run || true)"
 iso_claude="$(count_target /home/deva/.claude "$iso_out")"


### PR DESCRIPTION
Supersedes #406 (closed; its ssh transport work carries forward). tmux interaction graduates from four loose scripts to a built-in module — one CLI, two transports, and the sandbox line drawn exactly where it was designed.

Close #412

## The shape

    Direction           tool             sandbox
    ---------           ----             -------
    host -> container   deva.sh shell    intact — default, recommended
    agent <-> agent     tmux-bridge      intact — panes inside one server
    container -> host   deva-tmux        OPT-IN (--host-tmux)

## What

- **`scripts/deva-tmux`** (new, baked into both images): `ls / attach / tmux / bridge / setup / doctor` over two transport backends. **ssh** (default): authenticated, survives host reboots (launchd sshd), and runs the *host's* tmux client — zero client/server protocol coupling. **socat** (fallback): the old unauthenticated TCP daemon, kept for hosts without sshd, loud warning on every start. `DEVA_TMUX_TRANSPORT=auto|ssh|socat`; auto probes ssh, falls back. Both transports land the host server on `/tmp/host-tmux.sock`, so `tmux-bridge` Layer 2 and `htmux` muscle memory work unchanged.
- **Inert without provisioning** is the security property: the baked binary with no key and no daemon has no host reach. `deva.sh --host-tmux` is the single opt-in — mounts `~/.ssh` read-only (dedup-safe, user `-v` wins), passes `DEVA_HOST_USER`, and in repo mode mounts the launcher's `deva-tmux` over the image copy so flag semantics never skew against older images.
- **`deva.sh tmux` host-side group**: `setup` authorizes your key by appending to your *own* `authorized_keys` — the #406 draft did this from inside the container via a docker host-mount write, which is exactly the host-reach pattern this module exists to gate; moving it host-side deleted the scariest code in the draft. `host-daemon start|stop|status` manages the socat fallback (inline socat when the repo's scripts aren't installed). `doctor` for the host view.
- **Compat**: `deva-bridge-tmux` is now a shim (old flags → env → `deva-tmux bridge start --transport socat --foreground`); `deva-bridge-tmux-host` unchanged; `tmux-bridge` stays vendored byte-for-byte from smux (the read-guard TTL idea goes upstream, not into a fork).
- **Bug found by running it**: a backgrounded `ssh -N -L` inherits the caller's stdout, so `deva-tmux bridge start | tail` hung forever waiting for EOF — the #406 draft shared this latent bug. Bridge children now detach stdio into a state-dir log.

## Verified live (real macOS host, from inside the dev container)

- `deva-tmux doctor`: both transports probed layer by layer, auto-resolution picks ssh
- `deva-tmux ls`: real host sessions over ssh, host-side client
- ssh bridge AND socat bridge: host server landed on `/tmp/host-tmux.sock`, native container tmux client lists real sessions through it, `tmux-bridge list` drives real host panes (Layer 2 composition), `bridge stop` cleans pid + socket
- `--host-tmux` dry-run: `~/.ssh:ro` + `DEVA_HOST_USER` + launcher-copy mount, all dedup-safe
- mount-shape suite asserts off / on / user-`-v`-dedup provisioning shapes; shellcheck severity=error clean; full local battery green

## Design record

Parallax'd in #412: unified in-container CLI won over host-side-only module (the consumer is the agent, inside), facade-over-scripts (status quo that produced the mess), deleting the direction (breaks #405 users), and bind-mounting the socket (virtiofs can't carry unix sockets across the macOS VM boundary — noted as a possible Linux-only third backend later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)