### PR TITLE
feat(auth): provision credentials via --auth-with <missing-file>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--auth-with` provision mode: passing a non-existent credentials file
+  path now offers to create it via interactive TUI login instead of
+  erroring. The container runs with the file bind-mounted; after exit
+  deva validates and reports the captured credentials (subscription type,
+  expiry), or removes the placeholder on abort. Combine with `-Q --rm`
+  for a clean one-shot provisioning flow.
+
 ## [0.14.0] - 2026-07-10
 
 ### Added

--- a/agents/claude.sh
+++ b/agents/claude.sh
@@ -167,9 +167,17 @@ setup_claude_auth() {
             if [ -z "${CUSTOM_CREDENTIALS_FILE:-}" ]; then
                 auth_error "CUSTOM_CREDENTIALS_FILE not set for credentials-file auth"
             fi
-            AUTH_DETAILS="credentials-file ($CUSTOM_CREDENTIALS_FILE)"
+            if [ "$AUTH_PROVISION_MODE" = true ]; then
+                mkdir -p "$(dirname "$CUSTOM_CREDENTIALS_FILE")"
+                printf '{}' > "$CUSTOM_CREDENTIALS_FILE"
+                chmod 600 "$CUSTOM_CREDENTIALS_FILE"
+                AUTH_DETAILS="credentials-file (provisioning: $CUSTOM_CREDENTIALS_FILE)"
+                echo "Provisioning credentials: log in via the TUI to populate $CUSTOM_CREDENTIALS_FILE" >&2
+            else
+                AUTH_DETAILS="credentials-file ($CUSTOM_CREDENTIALS_FILE)"
+                echo "Using custom credentials: $CUSTOM_CREDENTIALS_FILE -> /home/deva/.claude/.credentials.json" >&2
+            fi
             DOCKER_ARGS+=("-v" "$CUSTOM_CREDENTIALS_FILE:/home/deva/.claude/.credentials.json")
-            echo "Using custom credentials: $CUSTOM_CREDENTIALS_FILE -> /home/deva/.claude/.credentials.json" >&2
             ;;
         *)
             auth_error "auth method '$method' not implemented"

--- a/agents/shared_auth.sh
+++ b/agents/shared_auth.sh
@@ -226,18 +226,95 @@ is_file_path() {
     [[ "$arg" == /* ]] || [[ "$arg" == ~* ]] || [[ "$arg" == ./* ]] || [[ "$arg" == ../* ]] || [[ "$arg" == *.json ]]
 }
 
-expand_and_validate_file() {
+AUTH_PROVISION_MODE=false
+
+expand_auth_file_tilde() {
     local path="$1"
     if [[ "$path" == ~* ]]; then
         path="${path/#\~/$HOME}"
     fi
-    if [ ! -f "$path" ]; then
-        auth_error "Credentials file not found: $path"
-    fi
+    printf '%s' "$path"
+}
+
+resolve_absolute_path() {
+    local path="$1"
     if [[ "$path" == /* ]]; then
-        echo "$path"
+        printf '%s' "$path"
     else
-        echo "$(cd "$(dirname "$path")" && pwd)/$(basename "$path")"
+        printf '%s/%s' "$(cd "$(dirname "$path")" && pwd)" "$(basename "$path")"
+    fi
+}
+
+expand_and_validate_file() {
+    local path
+    path="$(expand_auth_file_tilde "$1")"
+
+    if [ -f "$path" ]; then
+        resolve_absolute_path "$path"
+        return
+    fi
+
+    # File missing — attempt provision mode
+    local dir
+    dir="$(dirname "$path")"
+    if [ ! -d "$dir" ]; then
+        auth_error "Credentials file not found: $path" \
+                   "Parent directory does not exist: $dir"
+    fi
+
+    if [ ! -t 0 ]; then
+        auth_error "Credentials file not found: $path" \
+                   "Run interactively to provision via TUI login"
+    fi
+
+    printf 'Credentials file not found: %s\n' "$path" >&2
+    printf 'Create it via TUI login? [y/N] ' >&2
+    local reply
+    read -r reply
+    case "$reply" in
+        y | Y | yes | YES) ;;
+        *) auth_error "Aborted: credentials file not found" ;;
+    esac
+
+    AUTH_PROVISION_MODE=true
+    resolve_absolute_path "$path"
+}
+
+finish_auth_provision() {
+    [ "$AUTH_PROVISION_MODE" = true ] || return 0
+    [ "${DRY_RUN:-false}" = true ] && return 0
+    local f="${CUSTOM_CREDENTIALS_FILE:-}"
+    [ -n "$f" ] || return 0
+
+    local ok=false
+    if [ -s "$f" ]; then
+        if command -v jq >/dev/null 2>&1; then
+            jq -e '.claudeAiOauth.accessToken' "$f" >/dev/null 2>&1 && ok=true
+        else
+            grep -q '"accessToken"' "$f" 2>/dev/null && ok=true
+        fi
+    fi
+
+    if [ "$ok" = true ]; then
+        chmod 600 "$f" 2>/dev/null || true
+        echo "" >&2
+        echo "Credentials captured: $f" >&2
+        if command -v jq >/dev/null 2>&1; then
+            local sub expires_ms now_s days
+            sub=$(jq -r '.claudeAiOauth.subscriptionType // "unknown"' "$f" 2>/dev/null)
+            expires_ms=$(jq -r '.claudeAiOauth.expiresAt // 0' "$f" 2>/dev/null)
+            now_s=$(date +%s)
+            if [ "$expires_ms" -gt 0 ] 2>/dev/null; then
+                days=$(( (expires_ms / 1000 - now_s) / 86400 ))
+                echo "  subscription: $sub, expires in ~${days}d" >&2
+            else
+                echo "  subscription: $sub" >&2
+            fi
+        fi
+        echo "Reuse: deva claude --auth-with $f" >&2
+    else
+        rm -f "$f"
+        echo "warning: no credentials captured; removed placeholder $f" >&2
     fi
 }
 

--- a/deva.sh
+++ b/deva.sh
@@ -3684,12 +3684,22 @@ if [ "$EPHEMERAL_MODE" = false ]; then
         update_session_file
     fi
 
-    exec docker exec "${DOCKER_TERMINAL_ARGS[@]}" "$CONTAINER_NAME" /usr/local/bin/docker-entrypoint.sh "${AGENT_COMMAND[@]}"
+    if [ "$AUTH_PROVISION_MODE" = true ]; then
+        docker exec "${DOCKER_TERMINAL_ARGS[@]}" "$CONTAINER_NAME" /usr/local/bin/docker-entrypoint.sh "${AGENT_COMMAND[@]}" || true
+        finish_auth_provision
+    else
+        exec docker exec "${DOCKER_TERMINAL_ARGS[@]}" "$CONTAINER_NAME" /usr/local/bin/docker-entrypoint.sh "${AGENT_COMMAND[@]}"
+    fi
 else
     echo "Launching ${ACTIVE_AGENT} (ephemeral mode) via $(docker_image_ref)"
     write_session_file
-    if ! docker "${DOCKER_ARGS[@]}" "${AGENT_COMMAND[@]}"; then
-        echo "error: failed to launch ephemeral container" >&2
-        exit 1
+    if [ "$AUTH_PROVISION_MODE" = true ]; then
+        docker "${DOCKER_ARGS[@]}" "${AGENT_COMMAND[@]}" || true
+        finish_auth_provision
+    else
+        if ! docker "${DOCKER_ARGS[@]}" "${AGENT_COMMAND[@]}"; then
+            echo "error: failed to launch ephemeral container" >&2
+            exit 1
+        fi
     fi
 fi

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -152,6 +152,24 @@ Example:
 deva.sh claude --auth-with ~/work/claude-prod.credentials.json
 ```
 
+#### Provisioning new credentials
+
+If the file does not exist, deva offers to create it via TUI login:
+
+```bash
+deva claude -Q --rm --auth-with ~/creds/xxx-claude-max.credentials.json -- --resume
+# -> "Credentials file not found: .../xxx-claude-max.credentials.json"
+# -> "Create it via TUI login? [y/N]"
+# Log in via /login in the TUI, then exit when done.
+# -> "Credentials captured: .../xxx-claude-max.credentials.json"
+# -> "  subscription: max, expires in ~365d"
+# -> "Reuse: deva claude --auth-with .../xxx-claude-max.credentials.json"
+```
+
+Use `-Q` (bare mode) to avoid polluting your default config home with the
+new account's identity. The placeholder file is removed automatically if
+no credentials are captured.
+
 ## Codex
 
 ### Default: `--auth-with chatgpt`


### PR DESCRIPTION
## Summary

- `--auth-with path/to/new.credentials.json` where the file doesn't exist now
  offers interactive TUI login to populate it, instead of erroring
- Pre-creates `{}` placeholder (0600), bind-mounts it, lets claude's normal
  OAuth login populate it through the mount
- After container exit: validates captured credentials (jq or grep fallback),
  reports subscription type + expiry, or removes placeholder on abort
- Non-interactive invocations get a hard error with guidance
- Replaces the 5-step manual flow with one command:
  `deva claude -Q --rm --auth-with ~/creds/xxx.credentials.json -- --resume`

## Files changed

| File | What |
|------|------|
| `agents/shared_auth.sh` | `expand_and_validate_file` provision path + `finish_auth_provision` |
| `agents/claude.sh` | credentials-file case pre-creates placeholder when provisioning |
| `deva.sh` | No-exec launch + post-run harvest in both persistent/ephemeral paths |
| `docs/authentication.md` | Provisioning section with example |
| `CHANGELOG.md` | Unreleased entry |

## Test plan

- [ ] `deva claude -Q --rm --auth-with /tmp/test-new.credentials.json -- --resume` — confirm prompt, TUI login, credentials captured
- [ ] Same with existing file — normal auth, no prompt
- [ ] Non-interactive (piped stdin) with missing file — hard error
- [ ] Missing parent directory — error with hint
- [ ] Abort at confirm prompt — error, no placeholder left behind
- [ ] TUI exit without logging in — placeholder removed with warning
- [ ] Dry-run (`-n`) — no file created, no harvest attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)