### PR TITLE
feat(auth): bare --auth-with names resolve against the agent config home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--auth-with` bare names (`claude-max.credentials.json`, no slash) resolve
+  against the agent config home (`~/.config/deva/<agent>/`) as a named
+  credentials store; CWD checked first for compat. Provisioning a missing
+  bare name creates it in the store (#417)
+
 ## [0.14.1] - 2026-07-13
 
 ### Added

--- a/agents/shared_auth.sh
+++ b/agents/shared_auth.sh
@@ -245,9 +245,29 @@ resolve_absolute_path() {
     fi
 }
 
+# Bare credential names (no slash) live in the agent config home — the store.
+auth_store_dir() {
+    if [ -n "${CONFIG_HOME:-}" ]; then
+        printf '%s' "$CONFIG_HOME"
+    elif command -v default_config_home_for_agent >/dev/null 2>&1; then
+        default_config_home_for_agent "${ACTIVE_AGENT:-claude}"
+    else
+        printf '%s/deva/%s' "${XDG_CONFIG_HOME:-$HOME/.config}" "${ACTIVE_AGENT:-claude}"
+    fi
+}
+
 expand_and_validate_file() {
     local path
     path="$(expand_auth_file_tilde "$1")"
+
+    # Bare name: CWD first (compat), then the store; provision lands in the store.
+    if [[ "$path" != */* ]]; then
+        if [ -f "$path" ]; then
+            resolve_absolute_path "$path"
+            return
+        fi
+        path="$(auth_store_dir)/$path"
+    fi
 
     if [ -f "$path" ]; then
         resolve_absolute_path "$path"
@@ -257,7 +277,7 @@ expand_and_validate_file() {
     # File missing — attempt provision mode
     local dir
     dir="$(dirname "$path")"
-    if [ ! -d "$dir" ]; then
+    if [[ "$1" == */* ]] && [ ! -d "$dir" ]; then
         auth_error "Credentials file not found: $path" \
                    "Parent directory does not exist: $dir"
     fi

--- a/agents/shared_auth.sh
+++ b/agents/shared_auth.sh
@@ -246,9 +246,13 @@ resolve_absolute_path() {
 }
 
 # Bare credential names (no slash) live in the agent config home — the store.
+# Explicit --config-home root layouts clear CONFIG_HOME and set CONFIG_ROOT
+# (deva.sh), so honor the root before falling back to the XDG default.
 auth_store_dir() {
     if [ -n "${CONFIG_HOME:-}" ]; then
         printf '%s' "$CONFIG_HOME"
+    elif [ -n "${CONFIG_ROOT:-}" ]; then
+        printf '%s/%s' "$CONFIG_ROOT" "${ACTIVE_AGENT:-claude}"
     elif command -v default_config_home_for_agent >/dev/null 2>&1; then
         default_config_home_for_agent "${ACTIVE_AGENT:-claude}"
     else

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -152,6 +152,19 @@ Example:
 deva.sh claude --auth-with ~/work/claude-prod.credentials.json
 ```
 
+#### Bare names: the credentials store
+
+A bare `*.json` name (no slash) resolves against the agent config home
+(`~/.config/deva/claude/` by default) — a named credentials store:
+
+```bash
+deva claude --auth-with claude-max.credentials.json
+# -> ~/.config/deva/claude/claude-max.credentials.json
+```
+
+Resolution order: current directory first (compat), then the store.
+A missing bare name provisions into the store.
+
 #### Provisioning new credentials
 
 If the file does not exist, deva offers to create it via TUI login:

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -158,11 +158,12 @@ A bare `*.json` name (no slash) resolves against the agent config home
 (`~/.config/deva/claude/` by default) — a named credentials store:
 
 ```bash
-deva claude --auth-with claude-max.credentials.json
+deva.sh claude --auth-with claude-max.credentials.json
 # -> ~/.config/deva/claude/claude-max.credentials.json
 ```
 
 Resolution order: current directory first (compat), then the store.
+With an explicit `--config-home` root, the store is `<root>/<agent>/`.
 A missing bare name provisions into the store.
 
 #### Provisioning new credentials


### PR DESCRIPTION
Bare *.json names are store names now. CWD first (compat), then
~/.config/deva/<agent>/. Missing bare name provisions into the store.

Closes #417

Test plan:
- [x] bare name hit in store -> resolves to store path (unit)
- [x] bare name in CWD wins over store (unit)
- [x] bare miss non-tty -> hard error naming the store path (unit)
- [x] slash path with missing parent -> unchanged error (unit)
- [ ] interactive: deva claude --auth-with new.credentials.json prompts and provisions into ~/.config/deva/claude/

🤖 Generated with [Claude Code](https://claude.com/claude-code)