### PR TITLE
feat(name): embed agent CLI version in container names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DEVA_TRACE=1` and removes it on the next non-traced start. Covers
   subprocesses and tools that ignore the CA env vars; never touches the
   host trust store
+- Container names embed the agent CLI version from the image label:
+  `deva--claude-v2.1.204--auth-file-max--proj..hash`. Persistent
+  containers pin old images; a CLI bump now creates a distinct container
+  instead of silently attaching a stale CLI to the same config home.
+  Label-less images keep the bare agent name (#420)
 
 ### Changed
 - cctrace pin bumped 0.4.0 -> 0.11.0 (client profiles, shape-first

--- a/deva.sh
+++ b/deva.sh
@@ -929,6 +929,41 @@ compute_shape_hash() {
     short_hash "$combined" 8
 }
 
+# Agent CLI version from the image label. Persistent containers pin the
+# image they were created from; embedding the CLI version in the name keeps
+# version drift visible and stops silent attach to a stale-version container
+# sharing the same config home (#420). check_image runs before any name is
+# built, so the inspect is reliable; label-less images fall back to the
+# bare agent name.
+AGENT_VERSION_TAG_CACHE="__unset__"
+agent_version_tag() {
+    local agent="$1"
+
+    if [ "$AGENT_VERSION_TAG_CACHE" != "__unset__" ]; then
+        printf '%s' "$AGENT_VERSION_TAG_CACHE"
+        return
+    fi
+
+    local label=""
+    case "$agent" in
+        claude) label="org.opencontainers.image.claude_code_version" ;;
+        codex) label="org.opencontainers.image.codex_version" ;;
+        gemini) label="org.opencontainers.image.gemini_cli_version" ;;
+        grok) label="org.opencontainers.image.grok_cli_version" ;;
+    esac
+
+    local ver=""
+    if [ -n "$label" ]; then
+        ver=$(docker image inspect --format "{{ index .Config.Labels \"$label\" }}" "$(docker_image_ref)" 2>/dev/null | head -1)
+        [ "$ver" = "<no value>" ] && ver=""
+        # Container names allow [a-zA-Z0-9_.-]; drop anything else (keep dots)
+        ver=$(printf '%s' "$ver" | tr -cd 'a-zA-Z0-9._-')
+    fi
+
+    AGENT_VERSION_TAG_CACHE="$ver"
+    printf '%s' "$ver"
+}
+
 build_container_name() {
     local prefix="$1"
     local agent="$2"
@@ -938,7 +973,12 @@ build_container_name() {
     local ephemeral="${6:-false}"
     local pid="${7:-}"
 
-    local name="${prefix}--${agent}--${auth_tag}--${slug}..${shape_hash}"
+    local agent_seg="$agent"
+    local agent_ver
+    agent_ver="$(agent_version_tag "$agent")"
+    [ -n "$agent_ver" ] && agent_seg="${agent}-v${agent_ver}"
+
+    local name="${prefix}--${agent_seg}--${auth_tag}--${slug}..${shape_hash}"
     if [ "$ephemeral" = true ] && [ -n "$pid" ]; then
         name="${name}--${pid}"
     fi

--- a/deva.sh
+++ b/deva.sh
@@ -935,11 +935,12 @@ compute_shape_hash() {
 # sharing the same config home (#420). check_image runs before any name is
 # built, so the inspect is reliable; label-less images fall back to the
 # bare agent name.
-AGENT_VERSION_TAG_CACHE="__unset__"
+AGENT_VERSION_TAG_CACHE_AGENT=""
+AGENT_VERSION_TAG_CACHE=""
 agent_version_tag() {
     local agent="$1"
 
-    if [ "$AGENT_VERSION_TAG_CACHE" != "__unset__" ]; then
+    if [ "$AGENT_VERSION_TAG_CACHE_AGENT" = "$agent" ]; then
         printf '%s' "$AGENT_VERSION_TAG_CACHE"
         return
     fi
@@ -960,6 +961,7 @@ agent_version_tag() {
         ver=$(printf '%s' "$ver" | tr -cd 'a-zA-Z0-9._-')
     fi
 
+    AGENT_VERSION_TAG_CACHE_AGENT="$agent"
     AGENT_VERSION_TAG_CACHE="$ver"
     printf '%s' "$ver"
 }
@@ -1117,8 +1119,8 @@ extract_agent_from_name() {
     local name="$1"
     local rest="${name#"${DEVA_CONTAINER_PREFIX}"}"
 
-    # New format: deva--<agent>--<auth>--<slug>..<hash>
-    if [[ "$rest" =~ ^--([a-z]+)-- ]]; then
+    # New format: deva--<agent>[-v<version>]--<auth>--<slug>..<hash>
+    if [[ "$rest" =~ ^--([a-z]+)(-v[A-Za-z0-9._-]+)?-- ]]; then
         printf '%s' "${BASH_REMATCH[1]}"
         return
     fi

--- a/scripts/test-container-slug.sh
+++ b/scripts/test-container-slug.sh
@@ -52,6 +52,11 @@ source_helpers() {
     eval "$(sed -n '/^generate_container_slug_for_path()/,/^}/p' "$REPO_ROOT/deva.sh")"
     eval "$(sed -n '/^compute_slug_components_for_path()/,/^}/p' "$REPO_ROOT/deva.sh")"
     eval "$(sed -n '/^extract_agent_from_name()/,/^}/p' "$REPO_ROOT/deva.sh")"
+    eval "$(sed -n '/^agent_version_tag()/,/^}/p' "$REPO_ROOT/deva.sh")"
+    AGENT_VERSION_TAG_CACHE_AGENT=""
+    AGENT_VERSION_TAG_CACHE=""
+    # No image label in unit tests unless a test stubs docker itself
+    docker_image_ref() { printf 'deva-test:none'; }
     DEVA_CONTAINER_PREFIX="deva"
 }
 
@@ -178,6 +183,26 @@ name=$(build_container_name "deva" "gemini" "vertex" "big-project" "11223344" "f
 assert_eq "persistent vertex auth" \
     "deva--gemini--vertex--big-project..11223344" "$name"
 
+# Versioned agent segment (#420): stub docker to return an image label
+docker() {
+    if [ "$1" = "image" ] && [ "$2" = "inspect" ]; then
+        printf '2.1.204\n'
+        return 0
+    fi
+    return 1
+}
+AGENT_VERSION_TAG_CACHE_AGENT="" AGENT_VERSION_TAG_CACHE=""
+name=$(build_container_name "deva" "claude" "auth-file-max" "myrepo" "ab12cd34" "false" "")
+assert_eq "persistent with agent version" \
+    "deva--claude-v2.1.204--auth-file-max--myrepo..ab12cd34" "$name"
+
+AGENT_VERSION_TAG_CACHE_AGENT="" AGENT_VERSION_TAG_CACHE=""
+name=$(build_container_name "deva" "mystery" "auth-default" "myrepo" "ab12cd34" "false" "")
+assert_eq "unmapped agent stays bare" \
+    "deva--mystery--auth-default--myrepo..ab12cd34" "$name"
+unset -f docker
+AGENT_VERSION_TAG_CACHE_AGENT="" AGENT_VERSION_TAG_CACHE=""
+
 # ──────────────────────────────────────
 echo "=== extract_agent_from_name ==="
 # ──────────────────────────────────────
@@ -193,6 +218,12 @@ assert_eq "new format gemini" "gemini" \
 
 assert_eq "new format ephemeral" "claude" \
     "$(extract_agent_from_name "deva--claude--api-key-abcd--myrepo..ab12cd34--99999")"
+
+assert_eq "versioned agent segment" "claude" \
+    "$(extract_agent_from_name "deva--claude-v2.1.204--auth-file-max--myrepo..ab12cd34")"
+
+assert_eq "versioned ephemeral" "codex" \
+    "$(extract_agent_from_name "deva--codex-v0.131.0--auth-default--myrepo..ab12cd34--4242")"
 
 assert_eq "legacy ephemeral" "claude" \
     "$(extract_agent_from_name "deva-myrepo..i47b207-claude-12345")"
@@ -254,7 +285,7 @@ out="$(run_dry claude --debug --dry-run || true)"
 cname="$(extract_container_name "$out")"
 if [ -n "$cname" ]; then
     assert_match "dry-run: new format structure" \
-        "^deva--claude--auth-default--" "$cname"
+        "^deva--claude(-v[A-Za-z0-9._-]+)?--auth-default--" "$cname"
     assert_match "dry-run: ends with ..hash" \
         '\.\.[a-f0-9]{8}$' "$cname"
     assert_no_match "dry-run: no old-style ..i prefix" \
@@ -267,7 +298,7 @@ out="$(run_dry codex --debug --dry-run || true)"
 cname="$(extract_container_name "$out")"
 if [ -n "$cname" ]; then
     assert_match "dry-run codex: agent in name" \
-        "^deva--codex--" "$cname"
+        "^deva--codex(-v[A-Za-z0-9._-]+)?--" "$cname"
 else
     fail "dry-run codex: could not extract container name"
 fi
@@ -276,7 +307,7 @@ out="$(run_dry gemini --debug --dry-run || true)"
 cname="$(extract_container_name "$out")"
 if [ -n "$cname" ]; then
     assert_match "dry-run gemini: agent in name" \
-        "^deva--gemini--" "$cname"
+        "^deva--gemini(-v[A-Za-z0-9._-]+)?--" "$cname"
 else
     fail "dry-run gemini: could not extract container name"
 fi
@@ -288,7 +319,7 @@ if [ -n "$cname" ]; then
     assert_match "dry-run ephemeral: has PID suffix" \
         '--[0-9]+$' "$cname"
     assert_match "dry-run ephemeral: agent in name" \
-        "^deva--claude--" "$cname"
+        "^deva--claude(-v[A-Za-z0-9._-]+)?--" "$cname"
 else
     fail "dry-run ephemeral: could not extract container name"
 fi


### PR DESCRIPTION
`deva--claude-v2.1.204--auth-file-max--proj..hash`

Version comes from the image's org.opencontainers.image.*_version label,
cached per run. check_image runs before any name is built so the inspect
is reliable. Label-less images fall back to the bare agent name.

Closes #420

Test plan:
- [x] unit (fake docker): claude -> deva--claude-v2.1.204--...
- [x] unit: unknown agent / missing label -> bare agent segment
- [x] unit: ephemeral pid suffix unaffected
- [x] ps auth-tag parsing splits on -- only; version segment transparent
- [ ] live: new container name carries version; old containers still listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)