### PR TITLE
fix(args): honor the -- contract — deva flags only before, verbatim after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   declared adjacent — a cctrace-only bump no longer rebuilds the npm
   agent layer or (rust image) the Playwright layer (#419)
 - `--trace` for codex and grok via cctrace client profiles (#418).
-  `deva codex -- --trace exec "..."` / `deva grok -- --trace -p "..."`
+  `deva codex --trace -- exec "..."` / `deva grok --trace -- -p "..."`
   wrap the agent with `cctrace <client> --no-open --`; always MITM capture
 - Container-scoped CA trust for traced sessions (#414): the entrypoint
   installs the cctrace MITM CA into the container system store when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   answers (poll-then-open; `DEVA_TRACE_OPEN=0` disables). Attaching to a
   persistent container created without the port warns instead (#425)
 
+### Fixed
+- `--` contract: deva-level flags (`--trace`, `--auth-with`) are now
+  interpreted only before `--`; everything after passes to the agent CLI
+  verbatim. `deva claude --trace -- --resume` traces; `deva claude --
+  --trace --resume` passes `--trace` through to claude as its own flag.
+  Previous behavior silently intercepted flags from both sides (#427)
+
 ### Changed
 - cctrace pin bumped 0.4.0 -> 0.11.0 (client profiles, shape-first
   categorization, `view --serve`)

--- a/agents/claude.sh
+++ b/agents/claude.sh
@@ -15,8 +15,10 @@ agent_prepare() {
     AUTH_METHOD="$PARSED_AUTH_METHOD"
     local -a remaining_args=("${PARSED_REMAINING_ARGS[@]+"${PARSED_REMAINING_ARGS[@]}"}")
 
-    # Detect --trace flag
+    # Detect --trace flag — only before the -- sentinel; after it, args
+    # belong to the agent CLI verbatim (#427). First -- is stripped.
     local use_trace=false
+    local seen_sep=false
     local -a claude_args=()
 
     if [ ${#remaining_args[@]} -gt 0 ]; then
@@ -24,8 +26,19 @@ agent_prepare() {
         while [ $i -lt ${#remaining_args[@]} ]; do
             local arg="${remaining_args[$i]}"
             case "$arg" in
+                --)
+                    if [ "$seen_sep" = false ]; then
+                        seen_sep=true
+                    else
+                        claude_args+=("$arg")
+                    fi
+                    ;;
                 --trace)
-                    use_trace=true
+                    if [ "$seen_sep" = true ]; then
+                        claude_args+=("$arg")
+                    else
+                        use_trace=true
+                    fi
                     ;;
                 *)
                     claude_args+=("$arg")

--- a/agents/codex.sh
+++ b/agents/codex.sh
@@ -33,13 +33,17 @@ agent_prepare() {
     AUTH_METHOD="$PARSED_AUTH_METHOD"
     local -a remaining_args=("${PARSED_REMAINING_ARGS[@]+"${PARSED_REMAINING_ARGS[@]}"}")
 
-    # Detect --trace flag (cctrace codex client profile, cctrace >= 0.11)
+    # Detect --trace flag — only before the -- sentinel; after it, args
+    # belong to the agent CLI verbatim (#427). First -- is stripped.
     local use_trace=false
+    local seen_sep=false
     if [ ${#remaining_args[@]} -gt 0 ]; then
         local -a filtered_args=()
         local arg
         for arg in "${remaining_args[@]}"; do
-            if [ "$arg" = "--trace" ]; then
+            if [ "$arg" = "--" ] && [ "$seen_sep" = false ]; then
+                seen_sep=true
+            elif [ "$arg" = "--trace" ] && [ "$seen_sep" = false ]; then
                 use_trace=true
             else
                 filtered_args+=("$arg")

--- a/agents/gemini.sh
+++ b/agents/gemini.sh
@@ -20,7 +20,18 @@ agent_prepare() {
 
     AGENT_COMMAND+=("--yolo")
 
-    AGENT_COMMAND+=("${remaining_args[@]+"${remaining_args[@]}"}")
+    # Strip the deva -- sentinel; everything after it is verbatim (#427).
+    local -a clean_args=()
+    local first_sep=false
+    local arg
+    for arg in "${remaining_args[@]+"${remaining_args[@]}"}"; do
+        if [ "$arg" = "--" ] && [ "$first_sep" = false ]; then
+            first_sep=true
+        else
+            clean_args+=("$arg")
+        fi
+    done
+    AGENT_COMMAND+=("${clean_args[@]+"${clean_args[@]}"}")
 
     setup_gemini_auth "$AUTH_METHOD"
 }

--- a/agents/grok.sh
+++ b/agents/grok.sh
@@ -18,13 +18,17 @@ agent_prepare() {
     AUTH_METHOD="$PARSED_AUTH_METHOD"
     local -a remaining_args=("${PARSED_REMAINING_ARGS[@]+"${PARSED_REMAINING_ARGS[@]}"}")
 
-    # Detect --trace flag (cctrace grok client profile, cctrace >= 0.11)
+    # Detect --trace flag — only before the -- sentinel; after it, args
+    # belong to the agent CLI verbatim (#427). First -- is stripped.
     local use_trace=false
+    local seen_sep=false
     if [ ${#remaining_args[@]} -gt 0 ]; then
         local -a filtered_args=()
         local arg
         for arg in "${remaining_args[@]}"; do
-            if [ "$arg" = "--trace" ]; then
+            if [ "$arg" = "--" ] && [ "$seen_sep" = false ]; then
+                seen_sep=true
+            elif [ "$arg" = "--trace" ] && [ "$seen_sep" = false ]; then
                 use_trace=true
             else
                 filtered_args+=("$arg")

--- a/agents/shared_auth.sh
+++ b/agents/shared_auth.sh
@@ -447,10 +447,23 @@ parse_auth_args() {
     local auth_method=""
     local -a remaining_args=()
     local i=0
+    local seen_sep=false
 
     while [ $i -lt ${#args[@]} ]; do
         case "${args[$i]}" in
+            --)
+                # First -- is the deva sentinel; keep it for downstream
+                # flag scanners (#427). Later --s pass through as-is.
+                seen_sep=true
+                remaining_args+=("${args[$i]}")
+                i=$((i + 1))
+                ;;
             --auth-with)
+                if [ "$seen_sep" = true ]; then
+                    remaining_args+=("${args[$i]}")
+                    i=$((i + 1))
+                    continue
+                fi
                 if [ $((i + 1)) -ge ${#args[@]} ]; then
                     auth_error "--auth-with requires a method or file path"
                 fi

--- a/deva.sh
+++ b/deva.sh
@@ -203,7 +203,7 @@ Examples:
 
 Advanced:
   deva.sh codex -v ~/.ssh:/home/deva/.ssh:ro -- -m gpt-5-codex
-  deva.sh claude -- --trace --continue   # Trace requests with cctrace
+  deva.sh claude --trace -- --continue   # Trace requests with cctrace
   deva.sh --show-config                  # Debug configuration
   deva.sh --no-docker claude             # Disable Docker-in-Docker auto-mount
 USAGE
@@ -3414,8 +3414,13 @@ fi
 # Warn if explicit --config-home is missing the agent's auth directory.
 # Only warn for default OAuth flows — api-key/bedrock/vertex/copilot don't need local auth dirs.
 # Peek at AGENT_ARGV + AGENT_ARGS to detect --auth-with before agent_prepare() runs.
+# Only scan before the -- sentinel; post-side --auth-with belongs to the
+# agent CLI and must not suppress the missing-dir warning (#427).
 _config_home_uses_default_auth=true
 for _arg in "${AGENT_ARGV[@]+"${AGENT_ARGV[@]}"}" "${AGENT_ARGS[@]+"${AGENT_ARGS[@]}"}"; do
+    if [ "$_arg" = "--" ]; then
+        break
+    fi
     if [ "$_arg" = "--auth-with" ]; then
         _config_home_uses_default_auth=false
         break

--- a/deva.sh
+++ b/deva.sh
@@ -3278,12 +3278,17 @@ else
     parse_wrapper_args
 fi
 
+# Preserve the -- boundary so agent_prepare can distinguish deva-level
+# flags (--auth-with, --trace) from agent CLI args: flags are only
+# interpreted before the sentinel; everything after passes verbatim (#427).
 if [ ${#AGENT_ARGS[@]} -gt 0 ]; then
     if [ ${#AGENT_ARGV[@]} -gt 0 ]; then
-        AGENT_ARGV=("${AGENT_ARGS[@]}" "${AGENT_ARGV[@]}")
+        AGENT_ARGV=("${AGENT_ARGS[@]}" "--" "${AGENT_ARGV[@]}")
     else
         AGENT_ARGV=("${AGENT_ARGS[@]}")
     fi
+elif [ ${#AGENT_ARGV[@]} -gt 0 ]; then
+    AGENT_ARGV=("--" "${AGENT_ARGV[@]}")
 fi
 
 _step "start"

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -164,10 +164,13 @@ The printed `docker run` line is diagnostic output. It masks secrets and may con
 ## Request Tracing
 
 ```bash
-deva.sh claude -- --trace --continue
-deva.sh codex -- --trace exec "fix the failing tests"
-deva.sh grok -- --trace -p "explain this stack trace"
+deva.sh claude --trace -- --continue
+deva.sh codex --trace -- exec "fix the failing tests"
+deva.sh grok --trace -- -p "explain this stack trace"
 ```
+
+`--trace` goes before `--`. Everything after `--` passes to the agent CLI
+verbatim and is never intercepted by deva.
 
 `--trace` wraps the agent with [cctrace](https://github.com/thevibeworks/cctrace),
 which records every API call the agent makes — messages, OAuth, usage/credits,


### PR DESCRIPTION
The arg pipeline flattened pre-`--` and post-`--` args before
agent_prepare, so `--trace`/`--auth-with` were intercepted from
both sides. `deva grok -- --trace` ate the flag instead of passing it
to grok — exactly what the user hit.

Fix: inject a `--` sentinel into AGENT_ARGV. Each agent's scanner
stops interpreting at it, strips it at command assembly.

```
deva claude --trace -- --resume   # traced, --resume to agent
deva claude -- --trace --resume   # NOT traced, both reach agent
deva --trace claude -- --resume   # traced (wrapper arg)
```

Closes #427

Test plan:
- [x] 9-point matrix: claude/grok/codex x (before/after/no-sep)
- [x] gemini sentinel strip (no --trace support)
- [x] shellcheck + bash -n clean
- [x] 63/63 slug tests pass
- [ ] live: deva grok --trace -- -p hello traces, deva grok -- --trace errors from grok

🤖 Generated with [Claude Code](https://claude.com/claude-code)