### PR TITLE
fix: surface docker's error when it rejects a .deva mount

### DIFF
--- a/deva.sh
+++ b/deva.sh
@@ -3950,8 +3950,12 @@ if [ "$EPHEMERAL_MODE" = false ]; then
     else
         # Container doesn't exist - try to create it
         echo "Creating persistent container: $CONTAINER_NAME"
-        error_output=$(docker "${DOCKER_ARGS[@]}" tail -f /dev/null 2>&1)
-        docker_exit=$?
+        # `|| docker_exit=$?` is load-bearing: under `set -e` a failing
+        # command-substitution assignment aborts the script AT the assignment,
+        # so the error handling below would be dead code on the exact path it
+        # exists for. Keep the assignment left of `||` to suspend `set -e`.
+        docker_exit=0
+        error_output=$(docker "${DOCKER_ARGS[@]}" tail -f /dev/null 2>&1) || docker_exit=$?
         if [ $docker_exit -ne 0 ]; then
             # Check if specifically a name collision (concurrent run)
             if echo "$error_output" | grep -qE 'already in use|Conflict'; then


### PR DESCRIPTION
Independent of the feature stack -- branched off main, mergeable on its own.

A .deva file with a mount docker rejects made deva.sh die silently: "Creating
persistent container: <name>" and nothing else. No container, no error.

deva.sh, persistent-container path (the default; ephemeral is opt-in):

    error_output=$(docker "${DOCKER_ARGS[@]}" tail -f /dev/null 2>&1)
    docker_exit=$?              # under set -euo pipefail: NEVER reached
    if [ $docker_exit -ne 0 ]; then ...   # dead code on failure

Under set -euo pipefail a failing command-substitution assignment aborts the
script AT the assignment, so the entire author-written error block never runs.
It was unreachable on the one path it exists for. Bind sources resolve on the
HOST fs (deva talks to the host daemon), so any VOLUME= docker rejects lands
exactly here.

Keeping the assignment left of `||` suspends set -e and captures the real exit;
the existing handler then prints docker's own stderr.

Test plan
- [x] repro with .deva VOLUME=/tmp:/mnt/bad:rx
      before: exit 125, output ends at "Creating persistent container", silent
      after:  exit 1, "docker: Error response from daemon: invalid mode: rx"
- [x] success path unaffected (container created and attached)
- [x] full local suite green (9/9), shellcheck --severity=error clean

Closes #484