### PR TITLE
docs: README restyle — short core-value, zh mirror, animated hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- README restyled around the core value — the container is the sandbox,
+  mounts are the contract; 190 -> ~80 lines, bilingual
+  (README.zh-CN.md), animated terminal hero SVG echoing deva.sh (#533)
+- Agent CLI pins refreshed: cctrace 0.25.1, codex 0.146.0, gemini-cli
+  0.53.0, grok 0.2.114, kimi-code 0.30.0 (#517)
+
 ## [0.18.1] - 2026-07-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,45 +1,24 @@
-# deva.sh
+English | [简体中文](README.zh-CN.md)
+
+<img src="docs/assets/deva-hero.svg" alt="deva.sh" width="640">
 
 [![CI](https://img.shields.io/github/actions/workflow/status/thevibeworks/deva/ci.yml?branch=main&label=ci)](https://github.com/thevibeworks/deva/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/badge/docs-docs.deva.sh-111111)](https://docs.deva.sh)
 [![Release](https://img.shields.io/github/v/release/thevibeworks/deva?sort=semver)](https://github.com/thevibeworks/deva/releases)
-[![Checks](https://img.shields.io/badge/checks-shellcheck%20%7C%20docs%20%7C%20smoke-222222)](#development)
+[![Docs](https://img.shields.io/badge/docs-docs.deva.sh-111111)](https://docs.deva.sh)
 [![License](https://img.shields.io/github/license/thevibeworks/deva)](LICENSE)
-[![Container](https://img.shields.io/badge/ghcr.io-thevibeworks%2Fdeva-blue)](https://github.com/thevibeworks/deva/pkgs/container/deva)
-[![Agents](https://img.shields.io/badge/agents-codex%20%7C%20claude%20%7C%20gemini%20%7C%20grok%20%7C%20kimi-222222)](#what-this-is)
 
-<sub>AI agents / LLMs: read [llms.txt](llms.txt) — the whole product in one fetch.</sub>
+Run Claude Code, Codex, Gemini, Grok, and Kimi inside Docker without pretending the agents' own permission prompts are the thing keeping you safe.
 
-Run Codex, Claude Code, Gemini, Grok, and Kimi inside Docker without pretending the agent's own sandbox is the thing keeping you safe.
+The core, in four lines:
 
-The container is the sandbox. Explicit mounts are the contract. Persistent project containers keep the workflow fast instead of rebuilding the same state every run.
-
-This repo is the source of truth for `deva.sh`.
-
-## What This Is
-
-- a Docker-based launcher for Codex, Claude, Gemini, Grok, and Kimi
-- one warm default container shape per project by default
-- explicit mount and env wiring instead of mystery behavior
-- per-agent config homes under `~/.config/deva/`
-- a shell script, not framework cosplay
-
-Primary entry point:
-
-- `deva.sh`
-
-Compatibility wrappers still exist:
-
-- `claude.sh`
-- `claude-yolo`
-
-## What This Is Not
-
-- Not a real safety boundary if you mount `/var/run/docker.sock`. That is host-root with extra steps.
-- Not a general-purpose devcontainer platform.
-- Not magic. If you mount your whole home read-write and hand the agent dangerous permissions, the agent can touch your whole home. Amazing how that works.
+- The container is the sandbox. All five agents run inside it with their built-in permission systems disabled (`claude --dangerously-skip-permissions`, `codex --dangerously-bypass-approvals-and-sandbox`, `gemini --yolo`, `grok --always-approve`, `kimi --yolo`). Isolation comes from Docker, not permission theater.
+- Mounts are the contract. Nothing crosses the host boundary except what you explicitly mount. No mystery behavior.
+- One warm persistent container per project, shared by all five agents. Packages, build caches, and scratch state stay warm instead of being rebuilt every run.
+- It's a bash script, not a framework.
 
 ## Quick Start
+
+60 seconds:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/thevibeworks/deva/main/install.sh | bash
@@ -48,143 +27,49 @@ cd ~/work/my-project
 deva.sh codex
 ```
 
-Then inspect the container if you want:
-
-```bash
-deva.sh shell
-deva.sh ps
-deva.sh stop
-```
-
-If you already use Codex, Claude, Gemini, Grok, or Kimi locally, deva will auto-link those auth homes into `~/.config/deva/` by default. If not, first run will ask you to authenticate inside the container.
-
-## Docs
-
-Start here if you want the short path:
-
-- [Quick Start](docs/quick-start.md)
-- [Authentication Guide](docs/authentication.md)
-- [Troubleshooting](docs/troubleshooting.md)
-
-Read these if you want to understand the machinery instead of cargo-culting commands:
-
-- [How It Works](docs/how-it-works.md)
-- [Philosophy](docs/philosophy.md)
-- [Advanced Usage](docs/advanced-usage.md)
-- [Tmux Bridge](docs/tmux-bridge-agent-comms.md)
-- [Custom Images](docs/custom-images.md)
-- [Docs Home](docs/index.md)
-
-Project policy and OSS housekeeping:
-
-- [Contributing](CONTRIBUTING.md)
-- [Security Policy](SECURITY.md)
-- [MIT License](LICENSE)
-- [Live Docs](https://docs.deva.sh)
-
-Examples:
-
-- [Examples](examples/README.md)
-
-Deep research note:
-
-- [UID/GID Handling Research](docs/UID-GID-HANDLING-RESEARCH.md)
-
-## How It Feels
-
-```text
-host workspace + auth home
-          |
-          v
-       deva.sh
-          |
-          v
-   docker run / docker exec
-          |
-          v
-   persistent project container
-     /home/deva + chosen agent
-```
-
-Default mode reuses one persistent container shape per project. Different mounts, explicit config homes, or auth modes split into separate containers. That keeps your packages, build cache, and scratch state warm without pretending every run is identical. `--rm` gives you a throwaway run when you actually want that.
+If you already use these agents locally, deva auto-links their auth homes into per-agent config homes under `~/.config/deva/` by default. If not, first run asks you to authenticate inside the container.
 
 ## Common Commands
 
 ```bash
-# Default agent is Claude
-deva.sh
-
-# Same container, different agents
-deva.sh codex
+deva.sh                  # default agent is Claude
+deva.sh codex            # same container, different agent
 deva.sh gemini
 deva.sh grok
 deva.sh kimi
 
-# Throwaway run
-deva.sh claude --rm
-
-# Inspect what deva would run
-deva.sh claude --debug --dry-run
-
-# Open a shell in the project container
-deva.sh shell
-
-# Read resolved config state
-deva.sh --show-config
+deva.sh claude --rm      # throwaway container
+deva.sh claude --debug --dry-run   # inspect the docker run before trusting it
+deva.sh shell            # shell into the project container
+deva.sh ps               # list containers
+deva.sh stop             # stop it
+deva.sh --show-config    # read resolved config
 ```
 
-## Sharp Edges
+## What This Is Not
 
-- `--no-docker` exists for a reason. If you do not need Docker-in-Docker, do not mount the socket.
+- Not safety magic. Mounting `/var/run/docker.sock` is host root with extra steps — deva will tell you so. If you don't need Docker-in-Docker, use `--no-docker`.
+- Mount your whole home read-write and hand the agent dangerous permissions, and the agent can touch your whole home. Amazing how that works.
 - `--host-net` gives the container broad network visibility. Use it when you mean it.
-- `-Q` is the bare mode. It skips config loading, autolink, and host config mounts. Good for clean repros.
-- `--config-home` is for isolated identities. Point it at a dedicated auth home, not your real `$HOME`.
-- The debug `docker run` line is for inspection, not guaranteed copy-paste shell syntax.
+- Not a general-purpose devcontainer platform.
 
-## Why This Exists
-
-Agent CLIs are useful. Their native permission theater is often not.
-
-deva moves the line:
-
-- give the agent broad power inside a container
-- decide exactly what crosses the host boundary
-- swap auth methods per project or per run
-- reuse the same default container shape across agents when mounts, config, and auth line up
-
-That is a better trade if you are working in a trusted repo and you actually want to get work done.
-
-## Development
-
-Basic checks:
-
-```bash
-./deva.sh --help
-./deva.sh --version
-./claude-yolo --help
-./scripts/version-check.sh
-bash tests/test_release_utils.sh
-bash tests/version-upgrade.sh
-./scripts/test-mount-shape.sh
-./scripts/test-version-targets.sh
-bash scripts/test-container-slug.sh
-uv run --with mkdocs --with mkdocs-material --with pymdown-extensions mkdocs build --strict
-```
-
-If you changed auth, mounts, or container lifecycle, run the real path. Do not ship "should work".
+The full security boundary is in [SECURITY.md](SECURITY.md).
 
 ## Images
 
-Stable release tags:
+Stable:
 
 - `ghcr.io/thevibeworks/deva:latest`
 - `ghcr.io/thevibeworks/deva:rust`
 - `ghcr.io/thevibeworks/deva:cloak` (CloakBrowser stealth Chromium, headed; `deva.sh -p cloak`)
 
-Nightly refresh tags:
+Nightly refresh: `ghcr.io/thevibeworks/deva:nightly`, `ghcr.io/thevibeworks/deva:nightly-rust`
 
-- `ghcr.io/thevibeworks/deva:nightly`
-- `ghcr.io/thevibeworks/deva:nightly-rust`
+## Docs
+
+Everything lives at [docs.deva.sh](https://docs.deva.sh): quick start, authentication, how it works, advanced usage, troubleshooting, philosophy.
+
+AI agents / LLMs: read [llms.txt](llms.txt) — the whole product in one fetch.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,76 @@
+[English](README.md) | 简体中文
+
+<img src="docs/assets/deva-hero.svg" alt="deva.sh" width="640">
+
+[![CI](https://img.shields.io/github/actions/workflow/status/thevibeworks/deva/ci.yml?branch=main&label=ci)](https://github.com/thevibeworks/deva/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/thevibeworks/deva?sort=semver)](https://github.com/thevibeworks/deva/releases)
+[![Docs](https://img.shields.io/badge/docs-docs.deva.sh-111111)](https://docs.deva.sh)
+[![License](https://img.shields.io/github/license/thevibeworks/deva)](LICENSE)
+
+在 Docker 里跑 Claude Code、Codex、Gemini、Grok、Kimi 五个 agent CLI，并且不再假装 agent 自带的权限弹窗是在保护你。
+
+核心就四条：
+
+- 容器即沙箱。五个 agent 全在容器里跑，agent 自带的权限系统全部关掉（`claude --dangerously-skip-permissions`、`codex --dangerously-bypass-approvals-and-sandbox`、`gemini --yolo`、`grok --always-approve`、`kimi --yolo`）。隔离靠 Docker，不靠 permission theater。
+- 挂载即契约。跨越主机边界的只有你显式挂载的东西，没有暗箱行为。
+- 一个项目一个常驻容器，五个 agent 共用。包、构建缓存、临时状态保温，不用每次重建。
+- 它就是一个 bash 脚本，不是框架。
+
+## Quick Start
+
+60 秒能跑通：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/thevibeworks/deva/main/install.sh | bash
+
+cd ~/work/my-project
+deva.sh codex
+```
+
+如果你本地已经在用这些 agent，deva 会默认把它们的 auth 目录自动链接到 `~/.config/deva/` 下的独立配置家目录；没有的话，首次运行会让你在容器里登录。
+
+## 常用命令
+
+```bash
+deva.sh                  # 默认 agent 是 Claude
+deva.sh codex            # 同一个容器，换 agent
+deva.sh gemini
+deva.sh grok
+deva.sh kimi
+
+deva.sh claude --rm      # 一次性容器，用完即扔
+deva.sh claude --debug --dry-run   # 先看 docker run 长啥样再信它
+deva.sh shell            # 进项目容器的 shell
+deva.sh ps               # 看容器
+deva.sh stop             # 停掉
+deva.sh --show-config    # 看解析后的配置
+```
+
+## 这不是什么
+
+- 不是安全魔法。挂载 `/var/run/docker.sock` 等于给了 host root，只是多绕了一步 —— deva 会明说。真不需要 Docker-in-Docker 就用 `--no-docker`。
+- 把整个 home 读写挂进去再给 agent 危险权限，agent 就能动你整个 home。就是这么神奇。
+- `--host-net` 给容器完整的网络可见性，想清楚再用。
+- 不是通用 devcontainer 平台。
+
+安全边界的完整说明见 [SECURITY.md](SECURITY.md)。
+
+## 镜像
+
+稳定版：
+
+- `ghcr.io/thevibeworks/deva:latest`
+- `ghcr.io/thevibeworks/deva:rust`
+- `ghcr.io/thevibeworks/deva:cloak`（CloakBrowser 隐身 Chromium，headed；`deva.sh -p cloak`）
+
+每日刷新：`ghcr.io/thevibeworks/deva:nightly`、`ghcr.io/thevibeworks/deva:nightly-rust`
+
+## 文档
+
+全部在 [docs.deva.sh](https://docs.deva.sh)：Quick Start、认证、工作原理、进阶用法、排障、设计哲学。
+
+AI agent / LLM 请直接读 [llms.txt](llms.txt)，一次抓取看完整个产品。
+
+## License
+
+MIT，见 [LICENSE](LICENSE)。

--- a/docs/assets/deva-hero.svg
+++ b/docs/assets/deva-hero.svg
@@ -1,0 +1,86 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace">
+  <title>deva.sh — the container is the sandbox, mounts are the contract</title>
+  <defs>
+    <linearGradient id="wordmark" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#34d399"/>
+      <stop offset="0.5" stop-color="#5eead4"/>
+      <stop offset="1" stop-color="#22d3ee"/>
+    </linearGradient>
+    <clipPath id="type-claude"><rect x="168" y="200" height="32">
+      <animate attributeName="width" calcMode="discrete" values="0;24;48;72" keyTimes="0;0.02;0.04;0.06" dur="15s" repeatCount="indefinite"/>
+    </rect></clipPath>
+    <clipPath id="type-codex"><rect x="168" y="200" height="32">
+      <animate attributeName="width" calcMode="discrete" values="0;0;20;40;60" keyTimes="0;0.2;0.213;0.227;0.24" dur="15s" repeatCount="indefinite"/>
+    </rect></clipPath>
+    <clipPath id="type-gemini"><rect x="168" y="200" height="32">
+      <animate attributeName="width" calcMode="discrete" values="0;0;24;48;72" keyTimes="0;0.4;0.413;0.427;0.44" dur="15s" repeatCount="indefinite"/>
+    </rect></clipPath>
+    <clipPath id="type-grok"><rect x="168" y="200" height="32">
+      <animate attributeName="width" calcMode="discrete" values="0;0;16;32;48" keyTimes="0;0.6;0.613;0.627;0.64" dur="15s" repeatCount="indefinite"/>
+    </rect></clipPath>
+    <clipPath id="type-kimi"><rect x="168" y="200" height="32">
+      <animate attributeName="width" calcMode="discrete" values="0;0;16;32;48" keyTimes="0;0.8;0.813;0.827;0.84" dur="15s" repeatCount="indefinite"/>
+    </rect></clipPath>
+  </defs>
+
+  <rect x="8" y="8" width="624" height="304" rx="14" fill="#0a0a0a" stroke="#173a2e" stroke-width="1.5"/>
+
+  <circle cx="34" cy="36" r="6" fill="#ef4444" opacity="0.5"/>
+  <circle cx="54" cy="36" r="6" fill="#eab308" opacity="0.5"/>
+  <circle cx="74" cy="36" r="6" fill="#22c55e" opacity="0.5"/>
+
+  <g transform="translate(604,38)">
+    <text text-anchor="middle" dominant-baseline="central" font-size="18" fill="#34d399" opacity="0.35">✧
+      <animateTransform attributeName="transform" type="rotate" from="0 0 0" to="360 0 0" dur="24s" repeatCount="indefinite"/>
+    </text>
+  </g>
+
+  <text x="320" y="122" text-anchor="middle" font-size="46" font-weight="bold" fill="url(#wordmark)">deva.sh</text>
+
+  <text x="248" y="153" font-size="15" fill="#34d399" textLength="9" lengthAdjust="spacingAndGlyphs">&gt;</text>
+  <text x="264" y="153" font-size="15" fill="#6b7280" textLength="117" lengthAdjust="spacingAndGlyphs">jai guru deva</text>
+  <rect x="388" y="140" width="8" height="16" fill="#34d399" opacity="0.9">
+    <animate attributeName="opacity" calcMode="discrete" values="0.9;0" keyTimes="0;0.5" dur="1.1s" repeatCount="indefinite"/>
+  </rect>
+
+  <text x="48" y="226" font-size="20" fill="#34d399" textLength="12" lengthAdjust="spacingAndGlyphs">$</text>
+  <text x="72" y="226" font-size="20" fill="#e5e7eb" textLength="84" lengthAdjust="spacingAndGlyphs">deva.sh</text>
+
+  <g>
+    <animate attributeName="opacity" calcMode="discrete" values="1;0" keyTimes="0;0.2" dur="15s" repeatCount="indefinite"/>
+    <text x="168" y="226" font-size="20" fill="#d97757" textLength="72" lengthAdjust="spacingAndGlyphs" clip-path="url(#type-claude)">claude</text>
+    <rect x="246" y="210" width="10" height="20" fill="#34d399">
+      <animate attributeName="opacity" calcMode="discrete" values="1;0" keyTimes="0;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g>
+    <animate attributeName="opacity" calcMode="discrete" values="0;1;0" keyTimes="0;0.2;0.4" dur="15s" repeatCount="indefinite"/>
+    <text x="168" y="226" font-size="20" fill="#74aa9c" textLength="60" lengthAdjust="spacingAndGlyphs" clip-path="url(#type-codex)">codex</text>
+    <rect x="234" y="210" width="10" height="20" fill="#34d399">
+      <animate attributeName="opacity" calcMode="discrete" values="1;0" keyTimes="0;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g>
+    <animate attributeName="opacity" calcMode="discrete" values="0;1;0" keyTimes="0;0.4;0.6" dur="15s" repeatCount="indefinite"/>
+    <text x="168" y="226" font-size="20" fill="#4796e3" textLength="72" lengthAdjust="spacingAndGlyphs" clip-path="url(#type-gemini)">gemini</text>
+    <rect x="246" y="210" width="10" height="20" fill="#34d399">
+      <animate attributeName="opacity" calcMode="discrete" values="1;0" keyTimes="0;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g>
+    <animate attributeName="opacity" calcMode="discrete" values="0;1;0" keyTimes="0;0.6;0.8" dur="15s" repeatCount="indefinite"/>
+    <text x="168" y="226" font-size="20" fill="#e5e7eb" textLength="48" lengthAdjust="spacingAndGlyphs" clip-path="url(#type-grok)">grok</text>
+    <rect x="222" y="210" width="10" height="20" fill="#34d399">
+      <animate attributeName="opacity" calcMode="discrete" values="1;0" keyTimes="0;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g>
+    <animate attributeName="opacity" calcMode="discrete" values="0;1" keyTimes="0;0.8" dur="15s" repeatCount="indefinite"/>
+    <text x="168" y="226" font-size="20" fill="#a78bfa" textLength="48" lengthAdjust="spacingAndGlyphs" clip-path="url(#type-kimi)">kimi</text>
+    <rect x="222" y="210" width="10" height="20" fill="#34d399">
+      <animate attributeName="opacity" calcMode="discrete" values="1;0" keyTimes="0;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+
+  <text x="320" y="266" text-anchor="middle" font-size="13" fill="#4b5563"># the container is the sandbox — mounts are the contract</text>
+</svg>


### PR DESCRIPTION
One idea up front: the container is the sandbox, mounts are the contract.

- README.md 190 -> ~80 lines; deep docs collapsed to docs.deva.sh pointer
- README.zh-CN.md section-for-section mirror with language switcher
- docs/assets/deva-hero.svg animated terminal hero (SMIL — gradient
  wordmark, blinking cursor, agent-name typing loop), echoes deva.sh site
- CHANGELOG backfills the #517 pin refresh under Unreleased

Closes #533

Preview the hero: https://raw.githubusercontent.com/thevibeworks/deva/docs/readme-restyle-533/docs/assets/deva-hero.svg

🤖 Generated with [Claude Code](https://claude.com/claude-code)