### PR TITLE
docs: README core block — outcomes, not mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- README core-value section rewritten around operator outcomes —
+  full-speed YOLO, host out of vendor code's reach, explicit boundary,
+  identity as a launch flag, official CLIs stock, zero workflow tax
+  (#536)
+
 ## [0.18.2] - 2026-08-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ English | [简体中文](README.zh-CN.md)
 
 Run Claude Code, Codex, Gemini, Grok, and Kimi inside Docker without pretending the agents' own permission prompts are the thing keeping you safe.
 
-The core, in four lines:
+The container is the sandbox, mounts are the contract. What that buys you:
 
-- The container is the sandbox. All five agents run inside it with their built-in permission systems disabled (`claude --dangerously-skip-permissions`, `codex --dangerously-bypass-approvals-and-sandbox`, `gemini --yolo`, `grok --always-approve`, `kimi --yolo`). Isolation comes from Docker, not permission theater.
-- Mounts are the contract. Nothing crosses the host boundary except what you explicitly mount. No mystery behavior.
-- One warm persistent container per project, shared by all five agents. Packages, build caches, and scratch state stay warm instead of being rebuilt every run.
-- It's a bash script, not a framework.
+- Full-speed agents. Permission prompts exist because the blast radius is your host. Make the blast radius a container and YOLO stops being reckless — all five agents run with their permission systems off (`claude --dangerously-skip-permissions`, `codex --dangerously-bypass-approvals-and-sandbox`, `gemini --yolo`, `grok --always-approve`, `kimi --yolo`). Worst case dies with the container.
+- The vendor's code never sees your host. Agent CLIs are fast-moving npm trees with auto-updaters. Here they are born inside the image: no `~/.ssh`, no `~/.aws`, no shell env soup, no browser profiles. Nothing to harvest.
+- Everything that crosses the boundary is explicit. Files: mounts. Secrets: the env you pass. Network: the posture you pick — default bridge, your proxy, `--host-net`, or nothing. If you didn't wire it, the agent doesn't have it.
+- Identity is a launch flag, not a global singleton. Per-agent config homes under `~/.config/deva/`, `--auth-with` / `--config-home` for the second account or API-key billing. Switch accounts per run; project, sessions, and container state stay put.
+- Official CLIs, stock. No protocol shims, no knockoff clients, no proxy MITM on your credentials. The compatibility layer is the container, not a translation layer — the best model always comes with its own best harness.
+- Feels like the naked CLI. Same cwd, same TTY, same OAuth flow. One warm container per project keeps packages and build caches hot. It's a bash script, not a framework.
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,12 +9,14 @@
 
 在 Docker 里跑 Claude Code、Codex、Gemini、Grok、Kimi 五个 agent CLI，并且不再假装 agent 自带的权限弹窗是在保护你。
 
-核心就四条：
+容器即沙箱，挂载即契约。这换来的是：
 
-- 容器即沙箱。五个 agent 全在容器里跑，agent 自带的权限系统全部关掉（`claude --dangerously-skip-permissions`、`codex --dangerously-bypass-approvals-and-sandbox`、`gemini --yolo`、`grok --always-approve`、`kimi --yolo`）。隔离靠 Docker，不靠 permission theater。
-- 挂载即契约。跨越主机边界的只有你显式挂载的东西，没有暗箱行为。
-- 一个项目一个常驻容器，五个 agent 共用。包、构建缓存、临时状态保温，不用每次重建。
-- 它就是一个 bash 脚本，不是框架。
+- 全速跑 agent。权限弹窗存在的理由是爆炸半径等于你的整机；把爆炸半径缩小到一个容器，YOLO 就不再是鲁莽 —— 五个 agent 全部关掉自带权限系统跑（`claude --dangerously-skip-permissions`、`codex --dangerously-bypass-approvals-and-sandbox`、`gemini --yolo`、`grok --always-approve`、`kimi --yolo`）。最坏结果随容器一起销毁。
+- 厂商代码永远见不到你的主机。agent CLI 是快速迭代、带自动更新的 npm 依赖树；在这里它们出生在镜像里：没有 `~/.ssh`、没有 `~/.aws`、没有 shell 环境变量汤、没有浏览器档案。想收集也无从下手。
+- 跨越边界的一切都是显式的。文件靠挂载，密钥靠你传的 env，网络靠你选的姿态 —— 默认 bridge、走你的代理、`--host-net`、或者干脆不联网。你没接的线，agent 就没有。
+- 身份是启动参数，不是全局单例。`~/.config/deva/` 下按 agent 分家，`--auth-with` / `--config-home` 切第二个账号或 API-key 计费。按次切账号，项目、会话、容器状态原地不动。
+- 官方 CLI，原封不动。不做协议转译、不用山寨客户端、credentials 不过任何中间人代理。兼容层是容器，不是协议 shim —— 最好的模型永远配它自家最好的 harness。
+- 手感和裸 CLI 一样。同一个 cwd、同一个 TTY、同一套 OAuth。每个项目一个保温容器，包和构建缓存常热。它就是一个 bash 脚本，不是框架。
 
 ## Quick Start
 

--- a/llms.txt
+++ b/llms.txt
@@ -12,8 +12,9 @@ are disabled by design — isolation comes from Docker, not permission theater:
 `codex --dangerously-bypass-approvals-and-sandbox`,
 `gemini --yolo`, `grok --always-approve`, and `kimi --yolo`. Auth
 lives in per-agent config homes under `~/.config/deva/` with OAuth (default) or
-API-key modes per agent; nothing crosses the host boundary except what you
-mount. Known sharp edge: mounting `/var/run/docker.sock` is host-root with
+API-key modes per agent, switchable per run (`--auth-with`, `--config-home`) so
+accounts and billing modes swap without touching project or session state;
+nothing crosses the host boundary except what you mount. Known sharp edge: mounting `/var/run/docker.sock` is host-root with
 extra steps, and deva will tell you so.
 
 Full docs: https://docs.deva.sh — if you can fetch one URL, fetch that one.


### PR DESCRIPTION
The old core block sold the mechanism (container = sandbox) and stopped. Senior devs buy outcomes; the block now states the mechanism once and lists the six things it buys: full-speed YOLO, vendor code caged off the host, explicit file/env/network boundary, per-run identity, stock official CLIs (containment as the compatibility layer, not protocol shims), naked-CLI feel.

All flags named are verified in deva.sh (--auth-with:2399, --config-home:143, --host-net:159).

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)