### PR TITLE
chore(versions): refresh agent CLI pins

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -8,20 +8,20 @@ DELTA_VERSION=0.19.2
 TMUX_VERSION=3.6a
 TMUX_SHA256=b6d8d9c76585db8ef5fa00d4931902fa4b8cbe8166f528f44fc403961a3f3759
 
-CLAUDE_CODE_VERSION=2.1.224
-CCTRACE_VERSION=0.37.0
+CLAUDE_CODE_VERSION=2.1.226
+CCTRACE_VERSION=0.38.1
 CODEX_VERSION=0.147.0
 GEMINI_CLI_VERSION=0.54.4
 GROK_CLI_VERSION=1.0.0
 KIMI_CODE_VERSION=0.34.0
-OPENCODE_VERSION=1.18.14
+OPENCODE_VERSION=1.18.15
 CCX_VERSION=v0.14.0
 COPILOT_API_VERSION=0ea08febdd7e3e055b03dd298bf57e669500b5c1
 PLAYWRIGHT_VERSION=1.62.1
 # CloakBrowser npm wrapper version. This also pins the Chromium binary:
 # the wrapper hardcodes per-arch free-binary versions (linux-x64 146.x.x.5,
 # linux-arm64 146.x.x.3), so bumping the wrapper is what moves Chromium.
-CLOAKBROWSER_WRAPPER_VERSION=0.5.5
+CLOAKBROWSER_WRAPPER_VERSION=0.5.6
 # Kimi WebBridge daemon + extension. No npm package; resolved from
 # cdn.kimi.com/webbridge/latest/version.json. Not consumed by any
 # build yet — Dockerfile.cloak starts baking it in #543.


### PR DESCRIPTION
Automated pin sweep from make versions-up. Images (core, main,
rust, cloak) were built locally at these exact versions before
pinning:

- claude-code 2.1.224 -> 2.1.226
- cctrace 0.37.0 -> 0.38.1
- opencode 1.18.14 -> 1.18.15
- cloakbrowser 0.5.5 -> 0.5.6