### PR TITLE
feat(inject): workspace context moves to local memory files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,10 @@
-@./.claude/CLAUDE.md
-@./CLAUDE.md
+# AGENTS.md
 
-<!-- deva:container-context -->
-# Container Environment (deva)
+Repo guidance for coding agents lives in CLAUDE.md (architecture,
+issue-based development workflow) and workflows/ (issue, commit, PR,
+release conventions). Read those before changing anything.
 
-You are inside a Docker container running Ubuntu Linux 24.04 LTS
-(Noble Numbat), not on the host machine. The workspace is a
-bind-mount from the host at the same absolute path, but the
-runtime is Linux.
-
-- This is Linux. Host-only tools (open, pbcopy, pbpaste, sw_vers,
-  diskutil, defaults, launchctl) are not available.
-- No display server. Browsers and GUI tools will not work.
-- Hard links (`ln` without -s) fail across mount boundaries.
-  Use `cp` or relative symbolic links (`ln -sr`).
-- Prefer relative paths for project-internal references.
-  Absolute paths work here but are container-specific.
-- $HOME is /home/deva (not /root). sudo works without password.
-- Pre-installed: Node.js, Python (use `uv`, not pip), Go, git,
-  gh, make, curl. pip is NOT in PATH.
-- Docker is available (socket mounted from host).
-- System packages and build caches persist across sessions.
-- Container details are in DEVA_* environment variables.
-<!-- /deva:container-context -->
+Container-environment facts are injected at launch into untracked
+local files (CLAUDE.local.md; a deva-owned AGENTS.md only in
+workspaces that have none). They are per-launch state and must never
+be committed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   identity as a launch flag, official CLIs stock, zero workflow tax
   (#536)
 
+## [0.18.2] - 2026-08-04
+
+### Changed
+- README restyled around the core value — the container is the sandbox,
+  mounts are the contract; 190 -> ~80 lines, bilingual
+  (README.zh-CN.md), animated terminal hero SVG echoing deva.sh (#533)
+- Agent CLI pins refreshed: cctrace 0.25.1, codex 0.146.0, gemini-cli
+  0.53.0, grok 0.2.114, kimi-code 0.30.0 (#517)
+
 ### Fixed
 - `--trace` UI dead on arrival with cctrace >= 0.36: its default port
   moved 9317 -> 8722, so the container bound 8722 while deva published
@@ -61,15 +70,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `http://127.0.0.1:9317` directly, checks `NetworkMode` on reattach);
   the real-mismatch warning now names the container and the exact
   `deva rm` command (#547)
-
-## [0.18.2] - 2026-08-04
-
-### Changed
-- README restyled around the core value — the container is the sandbox,
-  mounts are the contract; 190 -> ~80 lines, bilingual
-  (README.zh-CN.md), animated terminal hero SVG echoing deva.sh (#533)
-- Agent CLI pins refreshed: cctrace 0.25.1, codex 0.146.0, gemini-cli
-  0.53.0, grok 0.2.114, kimi-code 0.30.0 (#517)
+- Workspace context injection no longer dirties tracked memory files:
+  the container block used to be appended to `AGENTS.md` and
+  `.claude/CLAUDE.md` on every launch — phantom git diffs, committed
+  container context lying to host-side agents, and a circular-import
+  double-load. It now lands in `CLAUDE.local.md` (Claude Code's
+  native local memory file) plus a deva-owned `AGENTS.md` only when
+  the workspace has none (codex/grok/kimi/opencode read plain
+  AGENTS.md; their override variants shadow team files). Both are
+  auto-added to `.git/info/exclude`; legacy injected blocks are
+  stripped on next launch and marker-only files removed (#548)
 
 ## [0.18.1] - 2026-07-28
 

--- a/DEV-LOGS.md
+++ b/DEV-LOGS.md
@@ -13,6 +13,11 @@
 - Minimal markdown markers, no unnecessary formatting, minimal emojis.
 - Reference issue numbers in the format `#<issue-number>` for easy linking.
 
+# [2026-08-09] Dev Log: context injection moves to local files #548
+- Why: every launch appended the container block to tracked AGENTS.md/.claude/CLAUDE.md — phantom diffs, committed container-context lying to host agents, circular @imports triple-loading the block with contradictory persist lines.
+- What: inject_workspace_context now writes CLAUDE.local.md (Claude Code's sanctioned local memory, per official docs) + a deva-owned AGENTS.md only when the workspace has none (survey of codex/grok/kimi/opencode sources: all read plain AGENTS.md; AGENTS.override.md SHADOWS team files so it's unsafe to auto-write; kimi's .kimi-code/AGENTS.md is the only additive slot). Both excluded via .git/info/exclude (worktree-safe via rev-parse --git-path); legacy blocks healed on next launch, marker-only files removed. Repo's own polluted AGENTS.md rewritten (imports + block removed), untracked .claude/CLAUDE.md residue deleted.
+- Result: `git status` stays clean in every workspace. Open: gemini gets no context file (never did — reads only GEMINI.md).
+
 # [2026-08-09] Dev Log: --trace port pin, HOST_NET awareness, portless URL #547
 - Why: `--trace` was broken two ways — cctrace >= 0.36 binds 8722 while deva publishes 9317 (browser poll never connects), and HOST_NET=true makes `docker port` permanently empty (false "created without the trace port" warning on every reattach).
 - What: `cctrace --port 9317` pinned in all four traced agents; setup_trace_ui_port/announce_trace_ui detect host networking (skip -p, loopback URL, NetworkMode check on reattach); host PORT env honored (portless-style); portless `cctrace` alias registered per traced launch so the UI/dashboard live at a stable https://cctrace.localhost route (DEVA_TRACE_PORTLESS=0 opts out, DEVA_TRACE_URL overrides); DEVA_TRACE_UI_URL exported into the container on create AND reattach for the statusline trace chip.

--- a/deva.sh
+++ b/deva.sh
@@ -1882,21 +1882,70 @@ ${docker_line}"
 ${persist_line}
 - Container details are in DEVA_* environment variables."
 
-    local target
-    mkdir -p "$ws/.claude" 2>/dev/null || true
-    for target in "$ws/.claude/CLAUDE.md" "$ws/AGENTS.md"; do
-        if [ -f "$target" ] && grep -qF "$marker" "$target"; then
-            awk -v m="$marker" -v e="$end_marker" \
-                '$0==m{skip=1;next} $0==e{skip=0;next} !skip' \
-                "$target" > "${target}.deva.tmp" && mv "${target}.deva.tmp" "$target"
-        fi
+    # Heal legacy injections: deva used to append this block to AGENTS.md
+    # and .claude/CLAUDE.md — tracked team files — dirtying the repo on
+    # every launch and lying to host-side agents once committed. Strip the
+    # block; remove the file only when nothing else is left (deva made it).
+    local legacy
+    for legacy in "$ws/AGENTS.md" "$ws/.claude/CLAUDE.md"; do
+        [ -f "$legacy" ] && grep -qF "$marker" "$legacy" || continue
+        awk -v m="$marker" -v e="$end_marker" \
+            '$0==m{skip=1;next} $0==e{skip=0;next} !skip' \
+            "$legacy" > "${legacy}.deva.tmp" && mv "${legacy}.deva.tmp" "$legacy"
+        grep -q '[^[:space:]]' "$legacy" || rm -f "$legacy"
+    done
+    rmdir "$ws/.claude" 2>/dev/null || true
+
+    # Environment facts are per-launch state, not project knowledge: they
+    # belong in the personal, untracked memory layer. CLAUDE.local.md is
+    # Claude Code's native local memory file (loads alongside CLAUDE.md,
+    # meant to be gitignored) — the .env.local of memory files.
+    local target="$ws/CLAUDE.local.md"
+    if [ -f "$target" ] && grep -qF "$marker" "$target"; then
+        awk -v m="$marker" -v e="$end_marker" \
+            '$0==m{skip=1;next} $0==e{skip=0;next} !skip' \
+            "$target" > "${target}.deva.tmp" && mv "${target}.deva.tmp" "$target"
+    fi
+    {
+        [ -s "$target" ] && printf '\n'
+        printf '%s\n' "$marker"
+        printf '%s\n' "$context"
+        printf '%s\n' "$end_marker"
+    } >> "$target"
+
+    # Cross-agent fallback: codex, grok, kimi and opencode read plain
+    # AGENTS.md (none of them read CLAUDE.local.md, and their override
+    # files SHADOW a team AGENTS.md rather than stack). Own one — marker
+    # block only, clone-local — but never when the workspace has a real
+    # team AGENTS.md: those agents then simply run without the container
+    # note. The healing pass above already deleted a deva-owned file, so
+    # a plain existence check is enough.
+    if [ ! -f "$ws/AGENTS.md" ]; then
         {
-            [ -s "$target" ] && printf '\n'
             printf '%s\n' "$marker"
             printf '%s\n' "$context"
             printf '%s\n' "$end_marker"
-        } >> "$target"
-    done
+        } > "$ws/AGENTS.md"
+        _exclude_from_git "$ws" "AGENTS.md"
+    fi
+
+    _exclude_from_git "$ws" "CLAUDE.local.md"
+}
+
+# Keep a deva-owned file out of version control without touching the
+# tracked .gitignore: append to the clone-local exclude file. --git-path
+# resolves correctly for worktrees and submodules; no-op outside a repo
+# or when the path is already ignored.
+_exclude_from_git() {
+    local ws="$1" name="$2"
+    command -v git >/dev/null 2>&1 || return 0
+    local exclude
+    exclude=$(git -C "$ws" rev-parse --git-path info/exclude 2>/dev/null || true)
+    [ -n "$exclude" ] || return 0
+    case "$exclude" in /*) ;; *) exclude="$ws/$exclude" ;; esac
+    git -C "$ws" check-ignore -q "$name" 2>/dev/null && return 0
+    mkdir -p "$(dirname "$exclude")" 2>/dev/null || true
+    printf '%s\n' "$name" >> "$exclude" 2>/dev/null || true
 }
 
 parse_ccx_args() {


### PR DESCRIPTION
Stacked on #547's branch — retarget to main after it merges.

Every launch appended the container block to tracked AGENTS.md and .claude/CLAUDE.md: phantom diffs, committed container-context lying to host-side agents, circular @imports triple-loading the block with contradictory persist lines.

- CLAUDE.local.md is the injection target (Claude Code's sanctioned local memory file)
- deva-owned AGENTS.md only when the workspace has none — codex/grok/kimi/opencode read plain AGENTS.md, and their AGENTS.override.md variants SHADOW team files, so a real team file is never touched
- both excluded via .git/info/exclude (worktree-safe via rev-parse --git-path)
- legacy blocks healed on next launch; marker-only files removed; repo's own AGENTS.md pollution cleaned

Verified: legacy-polluted repo (blocks stripped, team content intact), fresh repo (git status clean), mode flip-flop, non-git dir.

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)